### PR TITLE
Fix selectors to show selected item

### DIFF
--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -36,7 +36,7 @@ function AreaDisplay({onChangeRegion, region}) {
         <AreaSelector
             regionNames={map(regions, 'name')}
             onChange={setRegion}
-            currentRegion={selectedRegion ? selectedRegion : null}
+            currentRegion={selectedRegion}
         />
     </div>
   );

--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -10,6 +10,7 @@ import {parseRegions, filterRegions} from '../../helpers/GeographyHelpers.js';
 
 function AreaDisplay({onChangeRegion, region}) {
   const [regions, setRegions] = useState([]);
+  const [selectedRegion, setSelectedRegion] = useState([]);
 
   //fetch region list from the API.
   // this only needs to be done once, when the component is loaded
@@ -25,17 +26,17 @@ function AreaDisplay({onChangeRegion, region}) {
   
   function setRegion(event) {
       const region = find(regions, function(r) {return r.name === event.value});
+      setSelectedRegion(event);
       
       onChangeRegion(region);
   };
     
   return (
     <div className="AreaDisplay">
-        <p>Currently Selected Region: {region ? region.name : "none"}</p>
         <AreaSelector
             regionNames={map(regions, 'name')}
             onChange={setRegion}
-            currentRegion={region ? region.name : null}
+            currentRegion={selectedRegion ? selectedRegion : null}
         />
     </div>
   );

--- a/src/components/DailyDataDisplay/DailyDataDisplay.js
+++ b/src/components/DailyDataDisplay/DailyDataDisplay.js
@@ -19,20 +19,16 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
   const [variable, setVariable] = useState(null);
   const [climatology, setClimatology] = useState(null);
 
-  function selectVariable(event) {
-      setVariable(event);
-  }
+  const selectVariable = setVariable;
   
-  function selectClimatology(event) {
-      setClimatology(event);
-  }
+  const selectClimatology = setClimatology;
   
   function dontSelectVariable(event){
-    //nothing happens here, as cascading selection is not in use
+    //no-op, as cascading selection is not in use
   }
   
   function dontSelectClimatology(event) {
-    // nothing happens here, as cascaing selection is not in use
+    // no-op, as cascading selection is not in use
   }
   
     useEffect(() => {
@@ -60,7 +56,7 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <VariableSelector 
             metadata={rasterMetadata}
-            value={variable ? variable : null}
+            value={variable}
             canReplace={false}
             onChange={selectVariable}
             onNoChange={dontSelectVariable}
@@ -70,7 +66,7 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <ClimatologySelector 
             metadata={rasterMetadata}
-            value={climatology ? climatology : null}
+            value={climatology}
             canReplace={false}
             onChange={selectClimatology}
             onNoChange={dontSelectClimatology}

--- a/src/components/DailyDataDisplay/DailyDataDisplay.js
+++ b/src/components/DailyDataDisplay/DailyDataDisplay.js
@@ -20,11 +20,11 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
   const [climatology, setClimatology] = useState(null);
 
   function selectVariable(event) {
-      setVariable(event.value);
+      setVariable(event);
   }
   
   function selectClimatology(event) {
-      setClimatology(event.value);
+      setClimatology(event);
   }
   
   function dontSelectVariable(event){
@@ -38,16 +38,16 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
     useEffect(() => {
       if(region && variable && climatology && rasterMetadata) {
         const datafiles = _.filter(rasterMetadata, {
-            'variable_id': variable.representative.variable_id,
+            'variable_id': variable.value.representative.variable_id,
             'experiment': emission,
             'model_id': model,
-            'start_date': climatology.representative.start_date,
-            'end_date': climatology.representative.end_date
+            'start_date': climatology.value.representative.start_date,
+            'end_date': climatology.value.representative.end_date
             });
         
         const api_calls = _.map(datafiles, datafile => {
             return annualCycleDataRequest(region.boundary, datafile.file_id, 
-                                   variable.representative.variable_id)
+                                   variable.value.representative.variable_id)
         });
         Promise.all(api_calls).then((api_responses)=> setDailyTimeSeries(api_responses));
       }
@@ -60,7 +60,7 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <VariableSelector 
             metadata={rasterMetadata}
-            value={variable ? variable.representative : null}
+            value={variable ? variable : null}
             canReplace={false}
             onChange={selectVariable}
             onNoChange={dontSelectVariable}
@@ -70,7 +70,7 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <ClimatologySelector 
             metadata={rasterMetadata}
-            value={climatology ? climatology.representative : null}
+            value={climatology ? climatology : null}
             canReplace={false}
             onChange={selectClimatology}
             onNoChange={dontSelectClimatology}
@@ -80,7 +80,7 @@ function DailyDataDisplay({region, rasterMetadata, model, emission}){
         {dailyTimeSeries ? 
           <DailyGraph 
             annualData={dailyTimeSeries}
-            variableInfo={variable}
+            variableInfo={variable.value}
           /> : 
           noGraphMessage({
                 climatology: climatology,

--- a/src/components/DataDisplay/DataDisplay.js
+++ b/src/components/DataDisplay/DataDisplay.js
@@ -32,20 +32,16 @@ function DataDisplay({region}) {
     }
   );
   
-  function selectModel(event) {
-      setModel(event);
-  }
+  const selectModel = setModel;
   
   function dontSelectModel(event){
-    //TODO: put something here. Ask Rod what.
+    //no-op, as we are not using cascading selection 
   }
   
-  function selectEmission(event) {
-      setEmission(event);
-  }
+  const selectEmission = setEmission;
   
   function dontSelectEmission(event){
-    //TODO: put something here. Ask Rod what.
+    //no-op, as we are not using cascading selection
   }
   
 
@@ -89,7 +85,7 @@ function DataDisplay({region}) {
             <span>Climate Model</span>
             <ModelSelector 
               metadata={rasterMetadata}
-              value={model ? model : null}
+              value={model}
               canReplace={false}
               onChange={selectModel}
               onNoChange={dontSelectModel}
@@ -101,7 +97,7 @@ function DataDisplay({region}) {
             <span> Emmissions Scenario</span> 
             <EmissionSelector 
               metadata={rasterMetadata}
-              value={emission ? emission : null}
+              value={emission}
               canReplace={false}
               onChange={selectEmission}
               onNoChange={dontSelectEmission}

--- a/src/components/DataDisplay/DataDisplay.js
+++ b/src/components/DataDisplay/DataDisplay.js
@@ -33,7 +33,7 @@ function DataDisplay({region}) {
   );
   
   function selectModel(event) {
-      setModel(event.value);
+      setModel(event);
   }
   
   function dontSelectModel(event){
@@ -41,7 +41,7 @@ function DataDisplay({region}) {
   }
   
   function selectEmission(event) {
-      setEmission(event.value);
+      setEmission(event);
   }
   
   function dontSelectEmission(event){
@@ -57,24 +57,24 @@ function DataDisplay({region}) {
           <Tab eventKey="year" title="Yearly Indicators">
             {<YearlyDataDisplay
               region={region}
-              model={model ? model.representative.model_id : "PCIC-HYDRO"}
-              emission={emission? emission.representative.experiment : "historical, rcp85"}
+              model={model ? model.value.representative.model_id : "PCIC-HYDRO"}
+              emission={emission? emission.value.representative.experiment : "historical, rcp85"}
               rasterMetadata={_.filter(rasterMetadata, {"timescale": "yearly"})}
             />}
           </Tab>
           <Tab eventKey="month" title="Monthly Indicators">
             {<MonthlyDataDisplay
               region={region}
-              model={model ? model.representative.model_id : "PCIC-HYDRO"}
-              emission={emission ? emission.representative.experiment : "historical, rcp85"}
+              model={model ? model.value.representative.model_id : "PCIC-HYDRO"}
+              emission={emission ? emission.value.representative.experiment : "historical, rcp85"}
               rasterMetadata={_.filter(rasterMetadata, {"timescale": "monthly"})}
             />}
           </Tab>
           <Tab eventKey="day" title="Daily Indicators">
             {<DailyDataDisplay
               region={region}
-              model={model ? model.representative.model_id : "PCIC-HYDRO"}
-              emission={emission ? emission.representative.experiment : "historical, rcp85"}
+              model={model ? model.value.representative.model_id : "PCIC-HYDRO"}
+              emission={emission ? emission.value.representative.experiment : "historical, rcp85"}
               rasterMetadata={_.filter(rasterMetadata, {"timescale": "other"})}
             />}
           </Tab>
@@ -89,7 +89,7 @@ function DataDisplay({region}) {
             <span>Climate Model</span>
             <ModelSelector 
               metadata={rasterMetadata}
-              value={model ? model.representative : null}
+              value={model ? model : null}
               canReplace={false}
               onChange={selectModel}
               onNoChange={dontSelectModel}
@@ -101,7 +101,7 @@ function DataDisplay({region}) {
             <span> Emmissions Scenario</span> 
             <EmissionSelector 
               metadata={rasterMetadata}
-              value={emission ? emission.representative : null}
+              value={emission ? emission : null}
               canReplace={false}
               onChange={selectEmission}
               onNoChange={dontSelectEmission}

--- a/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
+++ b/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
@@ -17,7 +17,7 @@ function MonthlyDataDisplay({region, rasterMetadata, model, emission}){
   const [variable, setVariable] = useState(null);
 
   function selectVariable(event) {
-      setVariable(event.value);
+      setVariable(event);
   }
   
   function dontSelectVariable(event){
@@ -27,7 +27,7 @@ function MonthlyDataDisplay({region, rasterMetadata, model, emission}){
     useEffect(() => {
       if(region && variable && rasterMetadata) {
         const datafiles = _.filter(rasterMetadata, {
-            'variable_id': variable.representative.variable_id,
+            'variable_id': variable.value.representative.variable_id,
             'experiment': emission,
             'model_id': model
             });
@@ -35,7 +35,7 @@ function MonthlyDataDisplay({region, rasterMetadata, model, emission}){
         
         const api_calls = _.map(datafiles, datafile => {
             return annualCycleDataRequest(region.boundary, datafile.file_id, 
-                                   variable.representative.variable_id)
+                                   variable.value.representative.variable_id)
         });        
         Promise.all(api_calls).then((api_responses)=> setAnnualCycleTimeSeries(api_responses));
       }
@@ -48,7 +48,7 @@ function MonthlyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <VariableSelector 
             metadata={rasterMetadata}
-            value={variable ? variable.representative : null}
+            value={variable ? variable : null}
             canReplace={false}
             onChange={selectVariable}
             onNoChange={dontSelectVariable}
@@ -58,7 +58,7 @@ function MonthlyDataDisplay({region, rasterMetadata, model, emission}){
         {annualCycleTimeSeries ? 
           <AnnualCycleGraph 
             annualData={annualCycleTimeSeries}
-            variableInfo={variable}
+            variableInfo={variable.value}
           /> : 
           noGraphMessage({
               watershed: region,

--- a/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
+++ b/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
@@ -16,12 +16,10 @@ function MonthlyDataDisplay({region, rasterMetadata, model, emission}){
   const [annualCycleTimeSeries, setAnnualCycleTimeSeries] = useState(null);
   const [variable, setVariable] = useState(null);
 
-  function selectVariable(event) {
-      setVariable(event);
-  }
+  const selectVariable = setVariable;
   
   function dontSelectVariable(event){
-    //nothing happens here, as we are not using cascading selection
+    //no-op, as we are not using cascading selection
   }
   
     useEffect(() => {
@@ -48,7 +46,7 @@ function MonthlyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <VariableSelector 
             metadata={rasterMetadata}
-            value={variable ? variable : null}
+            value={variable}
             canReplace={false}
             onChange={selectVariable}
             onNoChange={dontSelectVariable}

--- a/src/components/YearlyDataDisplay/YearlyDataDisplay.js
+++ b/src/components/YearlyDataDisplay/YearlyDataDisplay.js
@@ -15,7 +15,7 @@ function YearlyDataDisplay({region, rasterMetadata, model, emission}){
   const [variable, setVariable] = useState(null);
 
   function selectVariable(event) {
-      setVariable(event.value);
+      setVariable(event);
   }
   
   function dontSelectVariable(event){
@@ -25,7 +25,7 @@ function YearlyDataDisplay({region, rasterMetadata, model, emission}){
     useEffect(() => {
       if(region && variable) {
         longTermAverageDataRequest(region.boundary, 
-                                   variable.representative.variable_id,
+                                   variable.value.representative.variable_id,
                                    model,
                                    emission,
                                    "yearly",
@@ -41,7 +41,7 @@ function YearlyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <VariableSelector 
             metadata={rasterMetadata}
-            value={variable ? variable.representative : null}
+            value={variable ? variable : null}
             canReplace={false}
             onChange={selectVariable}
             onNoChange={dontSelectVariable}
@@ -51,7 +51,7 @@ function YearlyDataDisplay({region, rasterMetadata, model, emission}){
         {longTermTimeSeries ? 
           <LongTermAverageGraph 
             longTermData={longTermTimeSeries}
-            variableInfo={variable}
+            variableInfo={variable.value}
             region={region}
           /> : 
           noGraphMessage({

--- a/src/components/YearlyDataDisplay/YearlyDataDisplay.js
+++ b/src/components/YearlyDataDisplay/YearlyDataDisplay.js
@@ -14,9 +14,7 @@ function YearlyDataDisplay({region, rasterMetadata, model, emission}){
   const [longTermTimeSeries, setLongTermTimeSeries] = useState(null);
   const [variable, setVariable] = useState(null);
 
-  function selectVariable(event) {
-      setVariable(event);
-  }
+  const selectVariable = setVariable;
   
   function dontSelectVariable(event){
     //nothing happens here, as we are not using cascading selection
@@ -41,7 +39,7 @@ function YearlyDataDisplay({region, rasterMetadata, model, emission}){
         {rasterMetadata ? 
           <VariableSelector 
             metadata={rasterMetadata}
-            value={variable ? variable : null}
+            value={variable}
             canReplace={false}
             onChange={selectVariable}
             onNoChange={dontSelectVariable}


### PR DESCRIPTION
This project uses sophisticated selectors from [pcic-react-components](https://github.com/pacificclimate/pcic-react-components). Previously I'd misunderstood how the selectors worked, and as a result, when you selected an item with a dropdown, the dropdown would remain blank - it would not show which item you had selected. I was passing it the wrong thing.

All components with a selector have been modified to store the correct component in state; in the case of MapDisplay a new state variable was added to do this.

Demo [here](https://services.pacificclimate.org/dev/scip/app/).

Resolves #28