### PR TITLE
Fix layout

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -13,17 +13,6 @@
   }
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
 .App-link {
   color: #61dafb;
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -24,27 +24,25 @@ function App() {
 
   return (
     <div className="App">
-      <header className="App-header">
-        <h1>Salmon Climate Impacts Portal</h1>
-        <Container fluid>
-          <Row>
-            <Col lg={6} md={6}>
-              <MapDisplay
-                region={region}
-              />
-              <AreaDisplay
-                onChangeRegion={setRegion}
-                region={region}
-              />
-            </Col>
-            <Col lg={6} md={6}>
-              <DataDisplay
-                region={region}
-              />
-            </Col> 
-          </Row>
-        </Container>        
-      </header>
+      <h1>Salmon Climate Impacts Portal</h1>
+      <Container fluid>
+        <Row>
+          <Col lg={6} md={6}>
+            <MapDisplay
+              region={region}
+            />
+            <AreaDisplay
+              onChangeRegion={setRegion}
+              region={region}
+            />
+          </Col>
+          <Col lg={6} md={6}>
+            <DataDisplay
+              region={region}
+            />
+          </Col>
+        </Row>
+      </Container>
     </div>
   );
 }


### PR DESCRIPTION
Hey, Lee, I decided try to fix the layout issue. My investigations pointed at the `<header className="App-header>` wrapper in the `<App>`. If you remove this wrapper altogether, then the Bootstrap CSS is not overridden and the layout looks like a standard Bootstrap app.

Questions: 

1. What was the intention in using the `<header>` wrapper? It is nominally [intended](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) for introductory and title content, but it wraps (wrapped) the entire app in this code.
2. What was the intention of applying class `App-header`? It was almost certainly what was overriding the Bootstrap CSS. I left it in the `App.css` file in case it contains something particularly important for the project, but I think you could remove it.