### PR TITLE
convert geoJSON polygons to WKT

### DIFF
--- a/src/helpers/GeographyHelpers.js
+++ b/src/helpers/GeographyHelpers.js
@@ -30,6 +30,7 @@ export function regionListUnion(lists) {
     return(_.unionBy(...lists, "name"));
 }
 
+
 // the frontend uses geoJSON format, but the backends expect WKT format;
 // convert from geoJSON to WKT
 export function geoJSONtoWKT(area) {
@@ -52,12 +53,21 @@ export function geoJSONtoWKT(area) {
         });
         wkt = wkt.concat("))");
     }
+    else if (area.type === "Polygon") {
+        wkt = "MULTIPOLYGON (((";
+        area.coordinates[0].forEach(function(point, index) {
+            wkt = wkt.concat(`${point[0]} ${point[1]},`);
+        });
+        wkt = wkt.slice(0, -1); //remove final comma
+        wkt = wkt.concat(")))");
+    }
     else if (area.type === "Point"){
         wkt = `POINT (${area.coordinates[0]} ${area.coordinates[1]})`
     }
     else{
-        console.log("other conversions not implemented yet.");
+        console.log(`Conversion for geoJSON ${area.type} is not implemented yet`);
         wkt = ""
     }
     return wkt;
 }
+


### PR DESCRIPTION
The SCIP backend provides data on regions in geoJSON form, but the PCEX backend requires `area` parameters to be in WKT, so the functions that query the PCEX backend in `pcex-backend.js` convert geoJSON to WKT before querying.

A bug was caused by the lack of a code to convert geoJSON Polygons to WKT Polygons . This meant that sometimes the PCEX backend was queried with a blank WKT string instead of an actual area, and returned the mean for the entire spatial extent of the file instead of the area of interest. This also meant changing areas to a _different_ area sometimes didn't update the graph, if both of them were buggy.

resolves #45 
resolves #38 