### PR TITLE
Update indicator data

### DIFF
--- a/public/basins.yaml
+++ b/public/basins.yaml
@@ -1,0 +1,11 @@
+# This file is a white list for drainage basins that will be
+# selectable in the app. It includes only basins we have indicator netCDF
+# coverage of.
+
+- Fraser River
+- Nass River
+- Skeena River
+- Southwest Coast
+- Stewart
+- Stikine River
+- Taku River

--- a/public/conservation_units.yaml
+++ b/public/conservation_units.yaml
@@ -1,0 +1,127 @@
+# This file is a white list for salmon conservation units, as defined
+# by DFO, that will be selectable in the app. It includes only
+# conservation units we have indicator netCDF
+# coverage of.
+
+ - (p)Adams and Momich Lakes-Early Summer Timing
+ - Akuklotz
+ - Aldrich
+ - Anderson/Seton-Early Summer Timing
+ - Asitika
+ - Atna
+ - Azuklotz
+ - Babine
+ - Bear
+ - Border
+ - Boundary Bay_FA_0.3
+ - Bowron-Early Summer Timing
+ - Bowser
+ - Bulkley
+ - Chiliwack-Early Summer Timing 
+ - Chilko-Early Summer Timing
+ - Chilko-Summer Timing
+ - Christina
+ - Chutine
+ - Cultus - Late Timing
+ - Damdochax/Winimasik
+ - Damshilgwit
+ - Dean River
+ - Dennis
+ - East Vancouver Island-Nanaimo_SP_1.x
+ - Footsore/Hodder
+ - Francois/Fraser-Summer Timing
+ - Fraser Canyon
+ - Fraser River
+ - Fraser River<<bin>>
+ - Fraser-Harrison Fall Transplant_FA_0.3<<Bin>>
+ - Fred Wright
+ - Great Central
+ - Harrion-Upstream Migrating-Late Timing
+ - Harrison River
+ - Harrison-Downstream Migrating-Late Timing
+ - Interior Fraser
+ - Johanson
+ - Kamloops-Early Summer Timing
+ - King Salmon
+ - Kitwancool
+ - Kluatantan
+ - Kluayaz
+ - Kuthai
+ - Kwinageese
+ - Lillooet
+ - Lillooet/Harrison-Late Timing
+ - Little Trapper
+ - Lower Fraser
+ - Lower Fraser River_FA_0.3
+ - Lower Fraser River_SP_1.3
+ - Lower Fraser River_SU_1.3
+ - Lower Fraser River-Upper Pitt_SU_1.3
+ - Lower Nass
+ - Lower Skeena
+ - Lower Stikine
+ - Lower Thompson
+ - Maria Slough_SU_0.3
+ - Maxan
+ - McDonnell
+ - Meziadin
+ - Middle & Upper Skeena
+ - Middle Fraser River-Portage_FA_1.3
+ - Middle Skeena
+ - Middle Skeena-Mainstem Tributaries
+ - Middle-Upper Skeena
+ - Morice
+ - Motase
+ - Muchalat
+ - Nahatlatch-Early Summer Timing
+ - North Barriere-Early Summer Timing
+ - North Thompson
+ - North Thompson_SP_1.3
+ - North Thompson_SU_1.3
+ - Northern Transboundary Fjords
+ - Oweegee
+ - Owikeno
+ - Pitt-Early Summer Timing
+ - Quesnel-Summer Timing
+ - Schoen
+ - Seton-Later Timing
+ - Shuswap Complex-Early Summer Timing
+ - Shuswap Complex-Late Timing
+ - Shuswap River_SU_0.3
+ - Sicintine
+ - Skeena River
+ - Skeena River-High Interior
+ - Slamgeesh
+ - South Atnarko Lakes
+ - South Thompson
+ - South Thompson_SU_0.3
+ - South Thompson-Bessette Creek_SU_1.2
+ - Spawning
+ - Sproat
+ - Stephens
+ - Stikine-Early Timing
+ - Stikine-Late Timing
+ - Sustut
+ - Tahitan
+ - Tahlo/Morrison
+ - Takla/Trembleur-Early Stuart Timing
+ - Takla/Trembleur/Stuart-Summer Timing
+ - Taku
+ - Taku-Early Timing
+ - Taku-Late Timing
+ - Taku-Mid Timing
+ - Taseko-Early Summer Timing
+ - Tatsamenie
+ - Unuk
+ - Unuk River
+ - Upper Adams River_SU_x.x
+ - Upper Bulkley River
+ - Upper Fraser River_SP_1.3
+ - Upper Knight
+ - Upper Nass
+ - Upper Nass River
+ - Upper Skeena
+ - Vernon
+ - Wannock
+ - Wannock[Owikeno]
+ - Widgeon
+ - Zymoetz

--- a/public/watersheds.yaml
+++ b/public/watersheds.yaml
@@ -1,0 +1,128 @@
+# This file is a white list for watersheds (as named in the
+# BC Freshwater Atlas) that will be selectable in the app.
+# It includes only watersheds we have indicator netCDF
+# coverage of.
+
+ - Adams River
+ - Alberni Inlet
+ - Atnarko River
+ - Babine Lake
+ - Babine River
+ - Barrington River
+ - Bella Coola River
+ - Big Bar Creek
+ - Big Creek
+ - Blackwater River
+ - Bonaparte River
+ - Bowron
+ - Bridge Creek
+ - Bulkley River
+ - Campbell River
+ - Cariboo River
+ - Chesletta River
+ - Chilako River
+ - Chiliwack River
+ - Chilko River
+ - Chukachida River
+ - Clearwater River
+ - Comox
+ - Cottonwood River
+ - Cowichan
+ - Deadman River
+ - Dog Creek
+ - Driftwood River
+ - Euchiniko Lake
+ - Euchiniko River
+ - Francois Lake
+ - Fraser Canyon
+ - Gold River
+ - Green Lake
+ - Guichon Creek
+ - Harrison River
+ - Herrick Creek
+ - Homathko River
+ - Horsefly River
+ - Inklin River
+ - Iskut River
+ - Kakiddi Creek
+ - Kalum River
+ - Kinskuch River
+ - Kispiox River
+ - Kitimat River
+ - Klappan River
+ - Klinaklini River
+ - Lillooet
+ - Lower Bell -Irving River
+ - Lower Chilako River
+ - Lower Chilcotin River
+ - Lower Eutsuk Lake
+ - Lower Fraser
+ - Lower Iskut River
+ - Lower Nass River
+ - Lower Nechako Reservoir
+ - Lower Nicola River
+ - Lower North Thompson River
+ - Lower Salmon River
+ - Lower Skeena River
+ - Lower Stikine River
+ - Lower Trembleur Lake
+ - Mahood Lake
+ - McGregor River
+ - Mess Creek
+ - Middle Fraser
+ - Middle River
+ - Middle Skeena River
+ - Middle Stikine River
+ - Morice River
+ - Morkill River
+ - Murtle Lake
+ - Musleg River
+ - Nahlin River
+ - Nakina River
+ - Narcosli Creek
+ - Nass River
+ - Nazko River
+ - Nechako River
+ - Nikola River
+ - Nimpkish River
+ - Owikeno Lake
+ - Parksville
+ - Piman River
+ - Quesnel River
+ - Salmon River
+ - San Jose River
+ - Seton Lake
+ - Sheslay River
+ - Shuswap Lake
+ - South Thompson River
+ - Spatsizi River
+ - Squamish
+ - Stikine River
+ - Stuart Lake
+ - Stuart River
+ - Sustut River
+ - Tabor River
+ - Tahltan River
+ - Takla Lake
+ - Taseko River
+ - Taylor River
+ - Thompson River
+ - Tsitika River
+ - Tuya River
+ - Twan Creek
+ - Unuk River
+ - Upper Bell -Irving River
+ - Upper Chilcotin River
+ - Upper Dean River
+ - Upper Eutsuk Lake
+ - Upper Fraser River
+ - Upper Iskut River
+ - Upper Nass River
+ - Upper Nechako Reservoir
+ - Upper North Thompson River
+ - Upper Shuswap
+ - Upper Skeena River
+ - Upper Stikine River
+ - Upper Trembleur Lake
+ - Willow River
+ - Zymoetz River

--- a/src/components/DataDisplay/DataDisplay.js
+++ b/src/components/DataDisplay/DataDisplay.js
@@ -71,7 +71,7 @@ function DataDisplay({region}) {
               region={region}
               model={model ? model.value.representative.model_id : "PCIC-HYDRO"}
               emission={emission ? emission.value.representative.experiment : "historical, rcp85"}
-              rasterMetadata={_.filter(rasterMetadata, {"timescale": "other"})}
+              rasterMetadata={_.filter(rasterMetadata, {"timescale": "daily"})}
             />}
           </Tab>
           <Tab eventKey="population" title="Salmon Populations">

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -47,7 +47,7 @@ function DataMap({regionBoundary, watershedStreams, downstream}) {
             opacity={0.3}
             transparent={true}
             version={'1.1.1'}
-            layers={"x/storage/data/projects/comp_support/bc-srif/climatologies/fraser/annual/means/apf_flow_aClimMean_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19710101-20001231_fraser.nc/apf_flow"}
+            layers={"x/storage/data/projects/comp_support/bc-srif/climatologies/fraser+bccoast/annual/means/peakFlow_aClimMean_ensMean_VICGL-dynWat_rcp85_1971-2000_bccoast+fraser.nc/peakQmag_year"}
             time={"1985-07-02T00:00:00Z"}
             styles={"default-scalar/x-Occam"}
           />

--- a/src/data-services/pcex-backend.js
+++ b/src/data-services/pcex-backend.js
@@ -8,7 +8,7 @@ import {geoJSONtoWKT} from '../helpers/GeographyHelpers.js'
 // Functions for accessing the multimeta API, which returns a list of
 // available datafiles, and some metadata about each one
 
-export function getMultimeta(ensemble="scip_files") {
+export function getMultimeta(ensemble="scip_fraser_bccoast") {
     // returns the results of the multimeta API call - a list of available
     // netCDF raster data files and what data each contains
     // other API calls can be made to access this data.
@@ -72,7 +72,7 @@ export function annualCycleDataRequest(area, datafile, variable) {
 
 export function longTermAverageDataRequest(area, variable, model,
                                            emission, timescale, 
-                                           time, ensemble_name="scip_files") {
+                                           time, ensemble_name="scip_fraser_bccoast") {
     return axios.get(
     process.env.REACT_APP_PCEX_API_URL + "/data",
         {
@@ -104,7 +104,7 @@ export function getWatershedStreams(point) {
         {
             params: {
                 station: geoJSONtoWKT(point),
-                ensemble_name: "frapce_watershed"
+                ensemble_name: "fraser_bccoast_watershed"
             }
         }
     )
@@ -119,7 +119,7 @@ export function getDownstream(point) {
         {
             params: {
                 station: geoJSONtoWKT(point),
-                ensemble_name: "frapce_watershed"
+                ensemble_name: "fraser_bccoast_watershed"
             }
         }
     )

--- a/src/data-services/public.js
+++ b/src/data-services/public.js
@@ -1,0 +1,14 @@
+// This file offers functions that access config files in the 
+// "public" directory.
+import yaml from 'js-yaml';
+import axios from 'axios';
+
+// accesses whitelists of regions, which are yaml files containing
+// lists of regions to display.
+export function getWhitelist(whitelist) {
+    const url = `${process.env.PUBLIC_URL}/${whitelist}.yaml`;
+    
+    return axios.get(url)
+        .then(response => response.data)
+        .then(yaml.safeLoad);
+}

--- a/src/helpers/GeographyHelpers.js
+++ b/src/helpers/GeographyHelpers.js
@@ -87,22 +87,3 @@ export function geoJSONtoWKT(area) {
     }
     return wkt;
 }
-
-// these functions are needed because the whitelists and the region
-// lists are fetched simultaneously via Promise.all. Once you have all 
-// the data back, you need to sort out which API responses are which.
-export function isWhitelist(data) {
-    return(_.isArray(data) && _.isString(data[0]));
-}
-
-export function isRegionList(data) {
-    return(_.isArray(data) && _.isObject(data[0]) && _.has(data[0], 'name'));
-}
-
-export function findWhitelist(data) {
-    return _.find(data, isWhitelist);
-}
-
-export function findRegionLists(data) {
-    return _.filter(data, isRegionList);
-}


### PR DESCRIPTION
Updates the portal to use the new indicator (netCDF raster) data including coastal regions and further North along the Skeena and Nass basins.

Also implements a whitelist for the predefined watersheds and basins from the BC Freshwater Atlas and predefined salmon conservation units from DFO. Only regions for which we have data will be visible in the dropdowns.

resolves #51 
resolves #40 (incidentally, by switching to an entirely new dataset)
resolves #55

I haven't done a linting pass on this PR because there's some file overlap with the next (partially completed) one, and I fear a linting pass would make a merge very complicated.

[demo](https://services.pacificclimate.org/dev/scip/app/)