### PR TITLE
Show indicator data on the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ export REACT_APP_PCEX_API_URL=https://services.pacificclimate.org/dev/pcex/api
 # SCIP API - use an instance that is not in production
 export REACT_APP_SCIP_API_URL=http://docker-dev02.pcic.uvic.ca:30203/api/
 
+# ncWMS server
+export REACT_APP_NCWMS_URL=https://services.pacificclimate.org/dev/ncwms
+
 #tileserver URL
 export REACT_APP_BC_BASE_MAP_TILES_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/{z}/{x}/{y}.png
 

--- a/package.json
+++ b/package.json
@@ -28,13 +28,15 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-bootstrap": "^2.2.1",
+    "react-bootstrap-icons": "^1.10.3",
     "react-dom": "^17.0.2",
     "react-leaflet": "^3.1.0",
     "react-leaflet-draw": "^0.19.8",
     "react-plotly.js": "^2.5.1",
     "react-scripts": "4.0.3",
     "serve": "^14.0.1",
-    "web-vitals": "^1.1.2"
+    "web-vitals": "^1.1.2",
+    "zustand": "^4.4.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/public/map_indicators.yaml
+++ b/public/map_indicators.yaml
@@ -1,0 +1,56 @@
+# This file configures how indicators will be shown on the map.
+# Each indicator can be configured with a colour palette and
+# a boolean for whether or not to plot on the map with a logscaled
+# colour scale (only works when indicator is always greater than 0. 
+# List of available ncWMS colour palettes is here:
+# https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/04-usage.html
+
+# General rules of thumb: 
+# - flow indicators are logscaled, temperatures are not
+# - flow indicators use the seq-YlGnBl palette
+# - temperatures use the spectral palette (blue to red)
+# - flows use the blue heat palette (blue to more blue)
+# - miscellaneous things use the psu-viridis palette
+# - other things (like frequencies) use the default x-Occam palette
+
+highQ95_year:
+    logscale: false
+    palette: psu-viridis
+
+lowQ05_year:
+    logscale: false
+    palette: psu-viridis
+
+peakQmag_year:
+    logscale: false
+    palette: seq-BlueHeat-inv
+
+peakQday_year: 
+    logscale: false
+    palette: psu-viridis
+
+POT19dur_year: 
+    logscale: false
+    palette: psu-viridis
+
+POT19freq_year:
+    logscale: false
+    palette: psu-viridis
+
+#monthly indicators
+flow_month:
+    logscale: false
+    palette: seq-BlueHeat-inv
+
+tw_month:
+    logscale: false
+    palette: div-Spectral-inv
+
+#daily indicators
+flow_day:
+    logscale: false
+    palette: seq-BlueHeat-inv
+
+tw_day:
+    logscale: false
+    palette: div-Spectral-inv

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -53,6 +53,7 @@ function App() {
               onSelectOutlet={setSelectedOutlet}
               selectedOutlet={selectedOutlet}
             />
+            <hr />
             <AreaDisplay
               onChangeRegion={handleRegionChange}
               region={region}

--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -53,27 +53,23 @@ function AreaDisplay({onChangeRegion, region, selectedOutlet}) {
   // fetch basin list from the API.
   // this only needs to be done once, when the component is loaded
   useEffect(() => {
-      if(basins.length === 0) {
-          Promise.all([getBasins(), getWhitelist("basins")]).then(
+        Promise.all([getBasins(), getWhitelist("basins")]).then(
             ([basins, whitelist]) => {
-                setBasins(collateRegions([basins], whitelist));
-            }  
-          );
-      }
-  });
+            setBasins(collateRegions([basins], whitelist));
+        }  
+    );
+  }, []);
   
   // fetch species list from the API.
   // this only needs to be done once, when the component is loaded
   useEffect(() => {
-      if(taxons.length === 0) {
-          getTaxons().then(
-            data => {
-                setTaxons(data);
-                setSelectedTaxons(data); //start with all species selected
-            }  
-          );
-      }
-  });
+    getTaxons().then(
+        data => {
+            setTaxons(data);
+            setSelectedTaxons(data); //start with all species selected
+        }  
+    );
+  }, []);
     
   // returns a region given its kind and name
   function findRegion(kind, name) {

--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -219,10 +219,6 @@ function collateRegions(regions, whitelist) {
 
   return (
     <div className="AreaDisplay">
-      Select a region eiher using the circle marker tool on the map to place a
-      marker and select everything upstream of it, or from the dropdown watershed and
-      conservation unit menus below. You can narrow down regions shown on the menus
-      by river basin or species.
         <Container fluid>
             <Row>
                 <Col>

--- a/src/components/DailyDataDisplay/DailyDataDisplay.js
+++ b/src/components/DailyDataDisplay/DailyDataDisplay.js
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect } from 'react';
 import _ from 'lodash';
+import useStore from '../../store/useStore.js';
 import { annualCycleDataRequest } from '../../data-services/pcex-backend.js';
 import { noGraphMessage, noCommasExperiment } from '../../helpers/GraphHelpers.js';
 import DailyGraph from '../DailyGraph/DailyGraph.js';
@@ -17,10 +18,10 @@ function DailyDataDisplay({
   region, rasterMetadata, model, emission,
 }) {
   const [dailyTimeSeries, setDailyTimeSeries] = useState(null);
-  const [variable, setVariable] = useState(null);
   const [climatology, setClimatology] = useState(null);
-
-  const selectVariable = setVariable;
+  
+  const storeVariable = useStore((state) => state.setDailyIndicator);
+  const variable = useStore((state) => state.dailyIndicator);
 
   const selectClimatology = setClimatology;
 
@@ -67,7 +68,7 @@ function DailyDataDisplay({
             metadata={rasterMetadata}
             value={variable}
             canReplace={false}
-            onChange={selectVariable}
+            onChange={storeVariable}
             onNoChange={dontSelectVariable}
           />
         )

--- a/src/components/DataDisplay/DataDisplay.js
+++ b/src/components/DataDisplay/DataDisplay.js
@@ -5,6 +5,7 @@
 
 import {getMultimeta, flattenMultimeta} from '../../data-services/pcex-backend.js'
 import React, {useState, useEffect} from 'react';
+import useStore from '../../store/useStore.js'
 import YearlyDataDisplay from '../YearlyDataDisplay/YearlyDataDisplay.js'
 import MonthlyDataDisplay from '../MonthlyDataDisplay/MonthlyDataDisplay.js'
 import DailyDataDisplay from '../DailyDataDisplay/DailyDataDisplay.js'
@@ -18,8 +19,17 @@ import _ from 'lodash';
 function DataDisplay({region}) {
 
   const [rasterMetadata, setRasterMetadata] = useState(null);
-  const [model, setModel] = useState(null);
-  const [emission, setEmission] = useState(null);
+
+  const storeModel = useStore((state) => state.setModel);
+  const model = useStore((state) => state.model);
+  
+  const storeEmission = useStore((state) => state.setEmission);
+  const emission = useStore((state) => state.emission);
+  
+  // stores which tab or graph is active, for the benefit of the map, which changes
+  // displayed map data to match currently visible graph.
+  const setGraphTab = useStore((state) => state.setGraphTab);
+
   
   // fetch list of available datasets
   useEffect(() => {
@@ -32,22 +42,25 @@ function DataDisplay({region}) {
     }
   );
   
-  const selectModel = setModel;
-  
   function dontSelectModel(event){
     //no-op, as we are not using cascading selection 
   }
-  
-  const selectEmission = setEmission;
+
   
   function dontSelectEmission(event){
     //no-op, as we are not using cascading selection
   }
   
+  function handleTabSwitch(tab) {
+    if(tab !== "population") {
+        setGraphTab(tab);
+        }
+    }
 
   return (
     <div className="DataDisplay">
         <Tabs
+          onSelect={handleTabSwitch}
           id="data-display-tabs"
           >
           <Tab eventKey="year" title="Yearly Indicators">
@@ -87,7 +100,7 @@ function DataDisplay({region}) {
               metadata={rasterMetadata}
               value={model}
               canReplace={false}
-              onChange={selectModel}
+              onChange={storeModel}
               onNoChange={dontSelectModel}
             /> 
           </div> : 
@@ -99,7 +112,7 @@ function DataDisplay({region}) {
               metadata={rasterMetadata}
               value={emission}
               canReplace={false}
-              onChange={selectEmission}
+              onChange={storeEmission}
               onNoChange={dontSelectEmission}
             />
           </div> : 

--- a/src/components/DataDisplay/DataDisplay.js
+++ b/src/components/DataDisplay/DataDisplay.js
@@ -107,7 +107,7 @@ function DataDisplay({region}) {
           "Loading Available Datasets"}
         {rasterMetadata ?
           <div>
-            <span> Emmissions Scenario</span> 
+            <span> Emissions Scenario</span> 
             <EmissionSelector 
               metadata={rasterMetadata}
               value={emission}

--- a/src/components/DataDisplay/DataDisplay.js
+++ b/src/components/DataDisplay/DataDisplay.js
@@ -31,16 +31,12 @@ function DataDisplay({region}) {
   const setGraphTab = useStore((state) => state.setGraphTab);
 
   
-  // fetch list of available datasets
+  // fetch list of all available datasets. Only needs to be done once.
   useEffect(() => {
-    //only needs to be done once
-    if(!rasterMetadata) {
-        getMultimeta().then(data => {
-            setRasterMetadata(flattenMultimeta(data));
-        })
-        }
-    }
-  );
+    getMultimeta().then(data => {
+        setRasterMetadata(flattenMultimeta(data));
+    })
+    }, []);
   
   function dontSelectModel(event){
     //no-op, as we are not using cascading selection 

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -99,7 +99,7 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
   }
   
 
-  console.log("dataset is");
+  console.log("dataset in Datamap is");
   console.log(dataset);
 
   return (

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -106,7 +106,8 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
   const wmsParams = dataset ? {
     layers: `x${dataset.file}/${dataset.variable}`,
     time: dataset.time,
-    styles: dataset.styles
+    styles: dataset.styles,
+    logscale: dataset.logscale
     }: {};
 
   return (
@@ -139,7 +140,7 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
             url={"https://services.pacificclimate.org/dev/ncwms"}
             format={'image/png'}
             noWrap={true}
-            opacity={0.3}
+            opacity={0.5}
             transparent={true}
             version={'1.1.1'}
             params={wmsParams}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -98,9 +98,16 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
     setCMMap(null);
   }
   
-
-  console.log("dataset in Datamap is");
-  console.log(dataset);
+  // WMSTileLayer does not update itself in response to updates made to the
+  // "layer" parameter, but does update in responds to changes made to
+  // parameters in the "params" objecf. Therefore, we need anything that
+  // might change over the course of a user session to be in this 
+  // object.
+  const wmsParams = dataset ? {
+    layers: `x${dataset.file}/${dataset.variable}`,
+    time: dataset.time,
+    styles: dataset.styles
+    }: {};
 
   return (
     <div className="DataMap">
@@ -127,7 +134,7 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
               edit={{edit: false}}
             />
           </FeatureGroup>
-          {dataset ?
+          {dataset &&
           <WMSTileLayer
             url={"https://services.pacificclimate.org/dev/ncwms"}
             format={'image/png'}
@@ -135,10 +142,8 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
             opacity={0.3}
             transparent={true}
             version={'1.1.1'}
-            layers={`x${dataset.file}/${dataset.variable}`}
-            time={dataset.time}
-            styles={dataset.styles}
-          /> : ""
+            params={wmsParams}
+          />
           }
         </BCBaseMap>
     </div>

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -137,7 +137,7 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
           </FeatureGroup>
           {dataset &&
           <WMSTileLayer
-            url={"https://services.pacificclimate.org/dev/ncwms"}
+            url={process.env.REACT_APP_NCWMS_URL}
             format={'image/png'}
             noWrap={true}
             opacity={0.5}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -10,7 +10,8 @@ import { EditControl } from 'react-leaflet-draw';
 import {useState} from 'react';
 import _ from 'lodash';
 
-function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet}) {
+
+function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, dataset}) {
   const viewport = BCBaseMap.initialViewport;
   const [cmMap, setCMMap] = useState(null);
   
@@ -89,6 +90,7 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet}) {
       return(l._radius && l._latlng);
     });
 
+
     if(oldMarker) {
       cmMap.removeLayer(layers[oldMarker]);
     }
@@ -96,6 +98,10 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet}) {
     setCMMap(null);
   }
   
+
+  console.log("dataset is");
+  console.log(dataset);
+
   return (
     <div className="DataMap">
         <BCBaseMap
@@ -121,6 +127,7 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet}) {
               edit={{edit: false}}
             />
           </FeatureGroup>
+          {dataset ?
           <WMSTileLayer
             url={"https://services.pacificclimate.org/dev/ncwms"}
             format={'image/png'}
@@ -128,10 +135,11 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet}) {
             opacity={0.3}
             transparent={true}
             version={'1.1.1'}
-            layers={"x/storage/data/projects/comp_support/bc-srif/climatologies/fraser+bccoast/annual/means/peakFlow_aClimMean_ensMean_VICGL-dynWat_rcp85_1971-2000_bccoast+fraser.nc/peakQmag_year"}
-            time={"1986-07-02T00:00:00Z"}
-            styles={"default-scalar/x-Occam"}
-          />
+            layers={`x${dataset.file}/${dataset.variable}`}
+            time={dataset.time}
+            styles={dataset.styles}
+          /> : ""
+          }
         </BCBaseMap>
     </div>
   );

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -107,7 +107,7 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
     layers: `x${dataset.file}/${dataset.variable}`,
     time: dataset.time,
     styles: dataset.styles,
-    logscale: dataset.logscale
+    logscale: dataset.logscale,
     }: {};
 
   return (
@@ -140,9 +140,9 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
             url={process.env.REACT_APP_NCWMS_URL}
             format={'image/png'}
             noWrap={true}
-            opacity={0.5}
             transparent={true}
             version={'1.1.1'}
+            opacity={dataset.opacity}
             params={wmsParams}
           />
           }

--- a/src/components/MapControls/ColourLegend.js
+++ b/src/components/MapControls/ColourLegend.js
@@ -1,0 +1,25 @@
+import {getColourBarURL} from '../../data-services/ncwms.js';
+
+function ColourLegend({mapDataset, minmax}) {
+
+    function colourbarURL() {
+        const url = process.env.REACT_APP_NCWMS_URL + "?service=WMS&request=GetLegendGraphic&colorbaronly=true&vertical=false";
+        return url;
+    }
+    
+    function palette() {
+        return mapDataset.styles.split('/')[1];
+    }
+    
+
+    return(
+        <div>
+          {minmax.min}
+          <img src={getColourBarURL(palette(), mapDataset.logscale)} />
+          {minmax.max}
+        </div>
+    );
+
+}
+
+export default ColourLegend;

--- a/src/components/MapControls/ColourLegend.js
+++ b/src/components/MapControls/ColourLegend.js
@@ -1,11 +1,6 @@
 import {getColourBarURL} from '../../data-services/ncwms.js';
 
 function ColourLegend({mapDataset, minmax}) {
-
-    function colourbarURL() {
-        const url = process.env.REACT_APP_NCWMS_URL + "?service=WMS&request=GetLegendGraphic&colorbaronly=true&vertical=false";
-        return url;
-    }
     
     function palette() {
         return mapDataset.styles.split('/')[1];

--- a/src/components/MapControls/ColourLegend.js
+++ b/src/components/MapControls/ColourLegend.js
@@ -1,6 +1,7 @@
+//Displays a colour bar and minimum and maximum values. Display-only component, not interactive.
 import {getColourBarURL} from '../../data-services/ncwms.js';
 
-function ColourLegend({mapDataset, minmax}) {
+function ColourLegend({mapDataset, minmax, units}) {
     
     function palette() {
         return mapDataset.styles.split('/')[1];
@@ -9,7 +10,7 @@ function ColourLegend({mapDataset, minmax}) {
 
     return(
         <div>
-          {minmax.min}
+          <strong>{mapDataset.variable} ({units}):</strong> {minmax.min}
           <img src={getColourBarURL(palette(), mapDataset.logscale)} />
           {minmax.max}
         </div>

--- a/src/components/MapControls/ColourLegend.js
+++ b/src/components/MapControls/ColourLegend.js
@@ -11,7 +11,10 @@ function ColourLegend({mapDataset, minmax, units}) {
     return(
         <div>
           <strong>{mapDataset.variable} ({units}):</strong> {minmax.min}
-          <img src={getColourBarURL(palette(), mapDataset.logscale)} />
+          <img 
+            src={getColourBarURL(palette(), mapDataset.logscale)}
+            alt={"colour legend for the map"} 
+          />
           {minmax.max}
         </div>
     );

--- a/src/components/MapControls/LogScaleCheckbox.js
+++ b/src/components/MapControls/LogScaleCheckbox.js
@@ -1,0 +1,25 @@
+// thia checkbox allows the user to control whether the raster data 
+// is colour-coded on the map with a linear or logairthmic scale.
+// if the data includes values of 0 or below, the colour coding must be linear.
+
+import React from 'react';
+import Form from 'react-bootstrap/Form';
+
+function LogScaleCheckbox({mapDataset, minmax, handleChange}) {
+
+    return (
+        <Form.Check
+            type="checkbox"
+            className="me-2"
+            checked={mapDataset.logscale}
+            onChange={handleChange}
+            inline
+            label={"Logarithmic Scale"}
+            title={minmax.min <= 0 ? "Logscale not possible for datasets containing 0" : "Logarithmic Scale"}
+            disabled={minmax.min <= 0}
+        />
+    );
+
+}
+
+export default LogScaleCheckbox;

--- a/src/components/MapControls/LogScaleCheckbox.js
+++ b/src/components/MapControls/LogScaleCheckbox.js
@@ -14,9 +14,9 @@ function LogScaleCheckbox({mapDataset, minmax, handleChange}) {
             checked={mapDataset.logscale}
             onChange={handleChange}
             inline
-            label={"Logarithmic Scale"}
-            title={minmax.min <= 0 ? "Logscale not possible for datasets containing 0" : "Logarithmic Scale"}
-            disabled={minmax.min <= 0}
+            label={"Log scale"}
+            title={minmax.min <= 0 ? "Logscale not possible for datasets containing values less than 1" : "Logarithmic Scale"}
+            disabled={minmax.min <= 1}
         />
     );
 

--- a/src/components/MapControls/MapControls.css
+++ b/src/components/MapControls/MapControls.css
@@ -1,0 +1,3 @@
+.xMapControls {
+    justify-content: space-between;
+}

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -41,12 +41,10 @@ function MapControls({onChange, mapDataset}) {
     const [datasetSeries, setDatasetSeries] = useState([]);
     const [indicatorConfig, setIndicatorConfig] = useState(null);
     
-    //load the indicator configuration options, if not already loaded
+    //load the indicator configuration options; only needs to be done once
     useEffect(() => {
-        if(!indicatorConfig) {
-            getIndicatorMapOptions().then((options) => setIndicatorConfig(options));
-        }
-    });
+        getIndicatorMapOptions().then((options) => setIndicatorConfig(options));
+    }, []);
     
     // this useEffect responds to changes in the selected dataset, via the mapDataset
     // prop. It fetches the minimum and maximum values of the dataset and stores them.

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -1,0 +1,124 @@
+// Determines which colour-coded raster dataset (and which timestamp within
+// that dataset) to display on the map, which it passes to its parent via onChange.
+// It narrows the selection down by indicator, model, and emissions scenario based
+// on what the user is viewing in graphs, accessed via the zustand store.
+// It selects climatology and individual timestamp based on user controls it displays.
+
+import useStore from '../../store/useStore.js'
+import React, {useState, useEffect} from 'react';
+import {getMetadata} from '../../data-services/pcex-backend.js';
+import {unravelObject, only} from '../../helpers/APIDataHelpers.js'
+import _ from 'lodash';
+
+function MapControls({onChange, mapDataset}) {
+    const graphTab = useStore((state) => state.graphTab);
+    const dailyIndicator = useStore((state) => state.dailyIndicator);
+    const yearlyIndicator = useStore((state) => state.yearlyIndicator);
+    const monthlyIndicator = useStore((state) => state.monthlyIndicator);
+    const model = useStore((state) => state.model);
+    const emission = useStore((state) => state.emission);
+    
+    const [timeMetadata, setTimeMetadata] = useState(null);
+    const [datasetSeries, setDatasetSeries] = useState([]);
+
+    // switch to a new datafile when the user changes which graph they are looking at
+    useEffect(() => {
+        console.log("model is");
+        console.log(model);
+        
+        const datafiles = graphTab === 'day' ? dailyIndicator 
+            : graphTab === 'month' ? monthlyIndicator 
+            : graphTab === 'year' ? yearlyIndicator
+            : undefined;
+
+        console.log("Indicator in useEffect is");
+        console.log(`graphTab: ${graphTab}, dailyINdictaor: ${dailyIndicator} monthly: ${monthlyIndicator} yearly ${yearlyIndicator}`);
+        console.log(datafiles);
+                
+        // select a datafile
+        if(datafiles) { 
+            setDatasetSeries(datafiles.value.contexts);
+            console.log(`received ${datafiles.value.contexts.length} datasets`);
+            //todo: non-random filtering here.
+            const dataset = datafiles.value.contexts[0];
+            
+//            console.log("dataset chosen randomly is");
+//            console.log(dataset)
+            
+            // fetch timestamp information for the selected datafile
+            getMetadata(dataset.file_id).then(data => {
+                const metadata = only(unravelObject(data, "file_id"));
+                console.log("time metadata is ");
+                console.log(metadata);
+                setTimeMetadata(data);
+//                console.log("here is the fetched data");
+//                console.log(metadata);
+                
+                const indicator = only(Object.keys(metadata.variables));
+                console.log(indicator);
+                
+                const timestamp = _.values(metadata.times)[0];
+                
+                const mapDataLayer = {
+                    file: metadata.filepath,
+                    variable: indicator,
+                    time: timestamp,
+                    styles: "default-scalar/x-Occam"
+                }
+                
+                onChange(mapDataLayer);
+            });
+        }
+        else {
+            console.log("no raster metadata");
+        }
+    }, [graphTab, dailyIndicator, yearlyIndicator, monthlyIndicator, model, emission]);
+
+    function describeTimestamp() {
+        const date = new Date(mapDataset.time);
+        const monthNames = ["January", "February", "March", 
+                "April", "May", "June", 
+                "July", "August", "September", 
+                "October", "November", "December"];
+        
+        if(graphTab === "year") {
+            return "annual";
+        }
+        else if(graphTab == "month") {
+            return monthNames[date.getMonth()];
+        }
+        else if(graphTab === "day") {
+            return `${monthNames[date.getMonth()]} ${date.getDate()}`;
+        }
+        else {
+            return "unset timestamp";
+        }
+    }
+    
+    function describeClimatology() {
+        if (timeMetadata) {
+            console.log(`start date is ${timeMetadata.start_date}`);
+            const start = new Date(timeMetadata.start_date);
+            const end = new Date(timeMetadata.end_date);
+            return `${start.getYear()}-${end.getYear()}`
+        }
+        else {
+            return "unset climatology";
+        }
+    }
+
+    function describeMap() {
+        if (mapDataset) {
+            return `${describeTimestamp()} mean ${mapDataset.variable} ${describeClimatology()}`;
+        }
+        else
+        {
+            return "Select an indicator on the Data Display to see it on the map";
+        }
+    }
+
+    return describeMap();
+}
+
+
+export default MapControls;

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -20,6 +20,7 @@ import PreviousClimatologyButton from './PreviousClimatologyButton.js';
 import ColourLegend from './ColourLegend.js';
 import LogScaleCheckbox from './LogScaleCheckbox';
 import PaletteSelector from './PaletteSelector';
+import OpacitySlider from './OpacitySlider';
 
 import './MapControls.css';
 
@@ -55,7 +56,6 @@ function MapControls({onChange, mapDataset}) {
     useEffect(() => {
         if(mapDataset) {
             getNcwmsMinMax(mapDataset.file, mapDataset.variable).then(data => {
-                console.log(data);
                 setDatasetMinMax(data);
             });
         }
@@ -134,6 +134,7 @@ function MapControls({onChange, mapDataset}) {
                     time: timestamp,
                     styles: `default-scalar/${palette}`,
                     logscale: logscale,
+                    opacity: 0.5,
                     file_id: metadata.file_id //not used by map but makes things easier.
                 }
                 onChange(mapDataLayer);
@@ -151,7 +152,8 @@ function MapControls({onChange, mapDataset}) {
     }
     
     // updates a single attribute of the displayed dataset, 
-    // used in cases where no fancy logic or data fetching is needed.
+    // used in cases where the dataset itself hasn't change, only
+    // the way it is displayed, so we don't need to fetch a new dataset.
     function updateMapDisplayParameter(parameter, value) {
         let newMapDataLayer = {...mapDataset};
         newMapDataLayer[parameter] = value;
@@ -159,13 +161,15 @@ function MapControls({onChange, mapDataset}) {
     }
 
     function handleLogScale(selected) {
-        console.log("handle log scale", selected);
         updateMapDisplayParameter("logscale", !mapDataset.logscale);
     }
     
     function handlePalette(selected) {
-        console.log("handle palette", selected);
         updateMapDisplayParameter("styles", "default-scalar/"+selected.target.value);
+    }
+    
+    function handleOpacity(selected) {
+        updateMapDisplayParameter("opacity", selected.target.valueAsNumber / 100);
     }
 
     function describeTimestamp() {
@@ -222,7 +226,7 @@ function MapControls({onChange, mapDataset}) {
     //advance to the next timestamp when the user clicks the corresponding button
     function nextTimestamp() {
         const currentTimeIndex = timeMetadata.times.findIndex((idx) => idx === mapDataset.time);
-        let newMapLayer = _.pick(mapDataset, ["file", "variable", "styles", "file_id", "logscale"]);
+        let newMapLayer = _.pick(mapDataset, ["file", "variable", "styles", "file_id", "logscale", "opacity"]);
         newMapLayer["time"] = timeMetadata.times[currentTimeIndex + 1];
         onChange(newMapLayer);
     }
@@ -239,7 +243,7 @@ function MapControls({onChange, mapDataset}) {
     //step back to the previous timestamp when user clicks the corresponding button
     function previousTimestamp() {
         const currentTimeIndex = timeMetadata.times.findIndex((idx) => idx === mapDataset.time);
-        let newMapLayer = _.pick(mapDataset, ["file", "variable", "styles", "file_id", "logscale"]);
+        let newMapLayer = _.pick(mapDataset, ["file", "variable", "styles", "file_id", "logscale", "opacity"]);
         newMapLayer["time"] = timeMetadata.times[currentTimeIndex -1 ];
         onChange(newMapLayer);
     }
@@ -284,6 +288,7 @@ function MapControls({onChange, mapDataset}) {
               time: timestamp,
               styles: mapDataset.styles,
               logscale: mapDataset.logscale,
+              opacity: mapDataset.opacity,
               file_id: metadata.file_id  
             };
             
@@ -332,6 +337,7 @@ function MapControls({onChange, mapDataset}) {
               time: timestamp,
               styles: mapDataset.styles,
               logscale: mapDataset.logscale,
+              opacity: mapDataset.opacity,
               file_id: metadata.file_id  
             };
             
@@ -384,6 +390,12 @@ function MapControls({onChange, mapDataset}) {
                     mapDataset={mapDataset}
                     minmax={datasetMinMax}
                     handleChange={handleLogScale}
+                  />
+                </Col>
+                <Col>
+                  <OpacitySlider
+                    mapDataset={mapDataset}
+                    handleChange={handleOpacity}
                   />
                 </Col>
               </Row>

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -17,6 +17,7 @@ import PreviousTimestampButton from './PreviousTimestampButton.js';
 import NextClimatologyButton from './NextClimatologyButton.js';
 import PreviousClimatologyButton from './PreviousClimatologyButton.js';
 import ColourLegend from './ColourLegend.js';
+import LogScaleCheckbox from './LogScaleCheckbox';
 
 import './MapControls.css';
 
@@ -146,11 +147,18 @@ function MapControls({onChange, mapDataset}) {
     function getDatasetAttributes(datasets, attributes) {
         return(_.uniqWith(_.map(datasets, d=> {return _.pick(d, attributes)}),_.isEqual));
     }
+    
+    // updates a single attribute of the displayed dataset, 
+    // used in cases where no fancy logic or data fetching is needed.
+    function updateMapDisplayParameter(parameter, value) {
+        let newMapDataLayer = {...mapDataset};
+        newMapDataLayer[parameter] = value;
+        onChange(newMapDataLayer);
+    }
 
-    //given the id of a dataset, return the values of one of its attributes 
-    function getDatasetAttribute(id, datasets, attribute) {
-        const ds = _.find(datasets, {file_id: id});
-        return ds[attribute];
+    function handleLogScale(selected) {
+        console.log("handle log scale", selected);
+        updateMapDisplayParameter("logscale", !mapDataset.logscale);
     }
 
     function describeTimestamp() {
@@ -350,10 +358,17 @@ function MapControls({onChange, mapDataset}) {
           </div>
           <div classname="ColourControls">
             {mapDataset ? (
-              <ColourLegend 
-                mapDataset={mapDataset}
-                minmax = {datasetMinMax} 
-              />
+              <div>
+                <ColourLegend 
+                  mapDataset={mapDataset}
+                  minmax={datasetMinMax} 
+                />
+                <LogScaleCheckbox
+                  mapDataset={mapDataset}
+                  minmax={datasetMinMax}
+                  handleChange={handleLogScale}
+                />
+              </div>
               ) : "Select an indicator on the data display to see it on the map"}
           </div>
         </div>

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -6,6 +6,7 @@
 
 import useStore from '../../store/useStore.js'
 import React, {useState, useEffect} from 'react';
+import {Container, Row, Col} from 'react-bootstrap';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import {getMetadata, flattenMetadata} from '../../data-services/pcex-backend.js';
 import {getNcwmsMinMax} from '../../data-services/ncwms.js'; 
@@ -18,6 +19,7 @@ import NextClimatologyButton from './NextClimatologyButton.js';
 import PreviousClimatologyButton from './PreviousClimatologyButton.js';
 import ColourLegend from './ColourLegend.js';
 import LogScaleCheckbox from './LogScaleCheckbox';
+import PaletteSelector from './PaletteSelector';
 
 import './MapControls.css';
 
@@ -160,6 +162,11 @@ function MapControls({onChange, mapDataset}) {
         console.log("handle log scale", selected);
         updateMapDisplayParameter("logscale", !mapDataset.logscale);
     }
+    
+    function handlePalette(selected) {
+        console.log("handle palette", selected);
+        updateMapDisplayParameter("styles", "default-scalar/"+selected.target.value);
+    }
 
     function describeTimestamp() {
         const date = new Date(mapDataset.time);
@@ -169,7 +176,7 @@ function MapControls({onChange, mapDataset}) {
                 "October", "November", "December"];
         
         if(graphTab === "year") {
-            return "annual";
+            return "Annual";
         }
         else if(graphTab === "month") {
             return monthNames[date.getMonth()];
@@ -195,7 +202,7 @@ function MapControls({onChange, mapDataset}) {
 
     function describeMap() {
         if (mapDataset) {
-            return `${describeTimestamp()} mean ${mapDataset.variable} ${describeClimatology()} (${mapDataset.logscale ? "logarithmic" : "linear"} colour scaling)`;
+            return `${describeTimestamp()} Mean ${describeClimatology()}`;
         }
         else
         {
@@ -335,7 +342,7 @@ function MapControls({onChange, mapDataset}) {
 
     return (
         <div classname="MapControls">
-          <div claaname="TimeControls">
+          <div classname="TimeContols">
             <ButtonGroup>
               <PreviousClimatologyButton
                 disabled={!previousClimatologyExists()}
@@ -350,27 +357,38 @@ function MapControls({onChange, mapDataset}) {
                 disabled={!nextTimestampExists()}
                 onClick={nextTimestamp}
               />
-             <NextClimatologyButton
+              <NextClimatologyButton
                 disabled={!nextClimatologyExists()}
                 onClick={nextClimatology}
               />
             </ButtonGroup>
           </div>
-          <div classname="ColourControls">
-            {mapDataset ? (
-              <div>
-                <ColourLegend 
-                  mapDataset={mapDataset}
-                  minmax={datasetMinMax} 
-                />
-                <LogScaleCheckbox
-                  mapDataset={mapDataset}
-                  minmax={datasetMinMax}
-                  handleChange={handleLogScale}
-                />
-              </div>
+          {mapDataset ? (
+            <Container>
+              <Row>
+                  <ColourLegend 
+                    mapDataset={mapDataset}
+                    minmax={datasetMinMax}
+                    units={timeMetadata.units} 
+                  />
+              </Row>
+              <Row>
+                <Col>
+                  <PaletteSelector
+                      mapDataset={mapDataset}
+                      handleChange={handlePalette}
+                  />
+                </Col>
+                <Col>
+                  <LogScaleCheckbox
+                    mapDataset={mapDataset}
+                    minmax={datasetMinMax}
+                    handleChange={handleLogScale}
+                  />
+                </Col>
+              </Row>
+            </Container>
               ) : "Select an indicator on the data display to see it on the map"}
-          </div>
         </div>
         );
 }

--- a/src/components/MapControls/NextClimatologyButton.js
+++ b/src/components/MapControls/NextClimatologyButton.js
@@ -13,7 +13,7 @@ function NextClimatologyButton({disabled, onClick}) {
             title="Next Climatology"
             disabled={disabled}
             onClick={onClick}> 
-                <BoxArrowInRight/> 
+                Climatology<BoxArrowInRight/> 
     </Button>
     );
 }

--- a/src/components/MapControls/NextClimatologyButton.js
+++ b/src/components/MapControls/NextClimatologyButton.js
@@ -1,0 +1,21 @@
+// button to go to the next climatology
+
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import {BoxArrowInRight} from 'react-bootstrap-icons';
+
+function NextClimatologyButton({disabled, onClick}) {
+
+    return (
+        <Button 
+            variant="primary" 
+            size="sm"
+            title="Next Climatology"
+            disabled={disabled}
+            onClick={onClick}> 
+                <BoxArrowInRight/> 
+    </Button>
+    );
+}
+
+export default NextClimatologyButton;

--- a/src/components/MapControls/NextTimestampButton.js
+++ b/src/components/MapControls/NextTimestampButton.js
@@ -13,7 +13,7 @@ function NextTimestampButton({disabled, onClick}) {
             title="Next Timestamp"
             disabled={disabled}
             onClick={onClick}> 
-                <ArrowRight/> 
+                Time<ArrowRight/> 
     </Button>
     );
 }

--- a/src/components/MapControls/NextTimestampButton.js
+++ b/src/components/MapControls/NextTimestampButton.js
@@ -1,0 +1,21 @@
+// button to go to the next timestamp in the current climatology
+
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import {ArrowRight} from 'react-bootstrap-icons';
+
+function NextTimestampButton({disabled, onClick}) {
+
+    return (
+        <Button 
+            variant="primary" 
+            size="sm"
+            title="Next Timestamp"
+            disabled={disabled}
+            onClick={onClick}> 
+                <ArrowRight/> 
+    </Button>
+    );
+}
+
+export default NextTimestampButton;

--- a/src/components/MapControls/OpacitySlider.js
+++ b/src/components/MapControls/OpacitySlider.js
@@ -1,0 +1,16 @@
+// Lets user set the opacity level of the map.
+
+import Form from 'react-bootstrap/Form';
+
+function OpacitySlider({mapDataset, handleChange}) {
+    return (
+        <Form.Range
+          value={mapDataset.opacity * 100} 
+          onChange={handleChange}
+        />
+    );
+    
+    
+}
+
+export default OpacitySlider;

--- a/src/components/MapControls/PaletteSelector.js
+++ b/src/components/MapControls/PaletteSelector.js
@@ -19,9 +19,78 @@ function PaletteSelector({mapDataset, handleChange}) {
     });
     
     // tries to create a human-friendly name to each palette
-    // if it cannot create a human-friendly name, just returns the original name.
+    // by expanding the ncWMS abbreviations for palette types, colours
+    // and "inverted" and replacing dashes with spaces.
     function humanFriendly(palette) {
-        return palette;
+        const comp = palette.split("-");
+        let hf = "";
+        
+        //general palette types, denoted by the first part of the palette name
+        const types = {
+            "x": "Cross Platform",
+            "div": "Divergent",
+            "seq": "Sequential",
+            "psu": "Matplotlib PUS",
+        };
+        
+        // attempts to understand colour sequences like BuRd for "Blue-Red"
+        // returns False if there's no such sequence
+        function expandedColorSequence(colseq) {
+            if (colseq === "Oranges" || colseq === "Purples") {
+                return false; //these palettes are misparsed by this function. 
+            }
+            let expanded = colseq;
+            const colours = {
+                "Bu": "Blue",
+                "Rd": "Red",
+                "Br": "Brown",
+                "Pi": "Pink",
+                "Or": "Orange",
+                "Gy": "Grey",
+                "Gn": "Green",
+                "Pu": "Purple",
+                "Yl": "Yellow",
+                "BG": "Blue-Green",
+                "YG": "Yellow-Green",
+                "Bk": "Black",
+                "PR": "Purple-Red"
+            };
+            for(let abbreviation in colours) {
+                expanded = expanded.replace(abbreviation, `, ${colours[abbreviation]}`);
+            }
+            
+            return expanded === colseq ? false : _.trim(expanded, ",");
+        }
+
+        if(comp[0] in types) {
+            hf = `${types[comp[0]]}:`;
+        }
+        else {
+            hf = comp[0];
+        }
+        
+        if(comp.length === 1) {
+            return hf;
+        }
+        else if(comp[1] === "inv") {
+            return `${hf} (inverted)`;
+        }
+        else if (expandedColorSequence(comp[1])) {
+            hf = `${hf} ${expandedColorSequence(comp[1])}`;
+        }
+        else {
+            hf = `${hf} ${comp[1]}`;
+        }
+        
+        if (comp.length === 2) {
+            return hf;
+        } 
+        else if(comp[2] === "inv") {
+            return `${hf} (inverted)`;
+        }
+        else {
+            return `${hf} ${comp[2]}`;
+        }
     }
 
     function makeOption(palette) {

--- a/src/components/MapControls/PaletteSelector.js
+++ b/src/components/MapControls/PaletteSelector.js
@@ -11,12 +11,10 @@ function PaletteSelector({mapDataset, handleChange}) {
     const [palettes, setPalettes] = useState();
 
 
-    //get the list of available palettes
+    //get the list of available palettes. Only needs to be done once.
     useEffect(() => {
-        if(!palettes) {
             getNcwmsPalettes(mapDataset.file, mapDataset.variable).then((palettes) => setPalettes(palettes));
-        }
-    });
+    }, []);
     
     // tries to create a human-friendly name to each palette
     // by expanding the ncWMS abbreviations for palette types, colours

--- a/src/components/MapControls/PaletteSelector.js
+++ b/src/components/MapControls/PaletteSelector.js
@@ -1,0 +1,44 @@
+// Allow user to select a palette to view map with.
+// Attempts to generate human-friendly names for the palettes.
+import {getNcwmsPalettes} from '../../data-services/ncwms.js';
+
+import React, {useState, useEffect} from 'react';
+import Form from 'react-bootstrap/Form';
+import _ from 'lodash';
+
+
+function PaletteSelector({mapDataset, handleChange}) {
+    const [palettes, setPalettes] = useState();
+
+
+    //get the list of available palettes
+    useEffect(() => {
+        if(!palettes) {
+            getNcwmsPalettes(mapDataset.file, mapDataset.variable).then((palettes) => setPalettes(palettes));
+        }
+    });
+    
+    // tries to create a human-friendly name to each palette
+    // if it cannot create a human-friendly name, just returns the original name.
+    function humanFriendly(palette) {
+        return palette;
+    }
+
+    function makeOption(palette) {
+        return (
+            <option key={palette} value={palette}>{humanFriendly(palette)}</option>
+        );
+    }
+
+    return (
+            <Form.Select 
+              onChange={handleChange}
+              enabled={true}
+              value={mapDataset.styles.split('/')[1]}>
+              
+                {_.map(palettes, makeOption)}
+            </Form.Select>
+    );
+}
+
+export default PaletteSelector;

--- a/src/components/MapControls/PreviousClimatologyButton.js
+++ b/src/components/MapControls/PreviousClimatologyButton.js
@@ -13,7 +13,7 @@ function PreviousClimatologyButton({disabled, onClick}) {
             title="Previous Climatology"
             disabled={disabled}
             onClick={onClick}> 
-                <BoxArrowInLeft/> 
+                <BoxArrowInLeft/>Climatology 
     </Button>
     );
 }

--- a/src/components/MapControls/PreviousClimatologyButton.js
+++ b/src/components/MapControls/PreviousClimatologyButton.js
@@ -1,0 +1,21 @@
+// button to go to the next climatology
+
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import {BoxArrowInLeft} from 'react-bootstrap-icons';
+
+function PreviousClimatologyButton({disabled, onClick}) {
+
+    return (
+        <Button 
+            variant="primary" 
+            size="sm"
+            title="Previous Climatology"
+            disabled={disabled}
+            onClick={onClick}> 
+                <BoxArrowInLeft/> 
+    </Button>
+    );
+}
+
+export default PreviousClimatologyButton;

--- a/src/components/MapControls/PreviousTimestampButton.js
+++ b/src/components/MapControls/PreviousTimestampButton.js
@@ -1,0 +1,21 @@
+// button to go to the next timestamp in the current climatology
+
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import {ArrowLeft} from 'react-bootstrap-icons';
+
+function PreviousTimestampButton({disabled, onClick}) {
+
+    return (
+        <Button 
+            variant="primary" 
+            size="sm"
+            title="Previous Timestamp"
+            disabled={disabled}
+            onClick={onClick}> 
+                <ArrowLeft/> 
+    </Button>
+    );
+}
+
+export default PreviousTimestampButton;

--- a/src/components/MapControls/PreviousTimestampButton.js
+++ b/src/components/MapControls/PreviousTimestampButton.js
@@ -13,7 +13,7 @@ function PreviousTimestampButton({disabled, onClick}) {
             title="Previous Timestamp"
             disabled={disabled}
             onClick={onClick}> 
-                <ArrowLeft/> 
+                <ArrowLeft/>Time 
     </Button>
     );
 }

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -32,8 +32,6 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
 
 
   function handleDatasetChange(dataset) {
-      console.log("dataset change!");
-      console.log(dataset);
       setMapDataset(dataset);
   }
 

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -3,13 +3,16 @@
 import './MapDisplay.css';
 import DataMap from '../DataMap/DataMap.js'
 import {getDownstream} from '../../data-services/pcex-backend.js'
+import MapControls from '../MapControls/MapControls.js';
 import React, {useState, useEffect} from 'react';
 import {validPoint} from '../../helpers/GeographyHelpers.js';
 
 function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
   
   const [downstream, setDownstream] = useState(null);
-  
+  const [mapDataset, setMapDataset] = useState(null);
+
+  // fetch downstream data from the PCEX API
     useEffect(() => {
       if(region && validPoint(region.outlet)) {
         getDownstream(JSON.parse(region.outlet)).then(data => {
@@ -21,9 +24,17 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
       }
   }, [region]);
   
+
   function handleSelectOutlet(point) {
       //just pass it up to the parent.
       onSelectOutlet(point);
+  }
+
+
+  function handleDatasetChange(dataset) {
+      console.log("dataset change!");
+      console.log(dataset);
+      setMapDataset(dataset);
   }
 
   return (
@@ -33,6 +44,11 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
           downstream={downstream}
           onSelectOutlet={handleSelectOutlet}
           selectedOutlet={selectedOutlet}
+          dataset={mapDataset}
+        />
+        <MapControls
+          onChange={handleDatasetChange}
+          mapDataset={mapDataset}
         />
     </div>
   );

--- a/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
+++ b/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
@@ -8,6 +8,7 @@ import React, { useState, useEffect } from 'react';
 import _ from 'lodash';
 import { annualCycleDataRequest } from '../../data-services/pcex-backend.js';
 import { noGraphMessage, noCommasExperiment } from '../../helpers/GraphHelpers.js';
+import useStore from '../../store/useStore.js';
 import AnnualCycleGraph from '../AnnualCycleGraph/AnnualCycleGraph.js';
 import VariableSelector from '../selectors/VariableSelector.js';
 
@@ -15,10 +16,10 @@ function MonthlyDataDisplay({
   region, rasterMetadata, model, emission,
 }) {
   const [annualCycleTimeSeries, setAnnualCycleTimeSeries] = useState(null);
-  const [variable, setVariable] = useState(null);
-
-  const selectVariable = setVariable;
-
+    
+  const storeVariable = useStore((state) => state.setMonthlyIndicator);
+  const variable = useStore((state) => state.monthlyIndicator);
+  
   function dontSelectVariable(event) {
     // no-op, as we are not using cascading selection
   }
@@ -55,7 +56,7 @@ function MonthlyDataDisplay({
             metadata={rasterMetadata}
             value={variable}
             canReplace={false}
-            onChange={selectVariable}
+            onChange={storeVariable}
             onNoChange={dontSelectVariable}
           />
         )

--- a/src/components/PopulationTable/PopulationTable.js
+++ b/src/components/PopulationTable/PopulationTable.js
@@ -32,7 +32,11 @@ export function PopulationTable({populations}) {
     
     return (
         <div class="ag-theme-alpine" style={{height: "400px", "text-align": "left"}}>
-        {noSalmonHere ? "No salmon populations recorded at this location" : 
+        {noSalmonHere ? 
+            "No salmon populations recorded at this location" : 
+            "Salmon populations in selected area"
+        }
+        {noSalmonHere ? "" :
             <AgGridReact
                 rowData={_.map(populations, tableizePop)}
                 columnDefs={ColumnDefs}>

--- a/src/components/TaxonSelector/TaxonCheckbox.js
+++ b/src/components/TaxonSelector/TaxonCheckbox.js
@@ -17,7 +17,6 @@ function TaxonCheckbox({taxon, selectedTaxons, onChange}) {
     };
     
     return (
-//        <label>
             <Form.Check
                 type="checkbox"
                 className="me-2"
@@ -26,8 +25,6 @@ function TaxonCheckbox({taxon, selectedTaxons, onChange}) {
                 inline
                 label={taxonString(taxon)}
             />
-//            {taxonString(taxon)}
-//        </label>
         );
 }
 

--- a/src/components/YearlyDataDisplay/YearlyDataDisplay.js
+++ b/src/components/YearlyDataDisplay/YearlyDataDisplay.js
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { longTermAverageDataRequest } from '../../data-services/pcex-backend.js';
+import useStore from '../../store/useStore.js';
 import { noGraphMessage, noCommasExperiment } from '../../helpers/GraphHelpers.js';
 import LongTermAverageGraph from '../LongTermAverageGraph/LongTermAverageGraph.js';
 import VariableSelector from '../selectors/VariableSelector.js';
@@ -13,10 +14,10 @@ function YearlyDataDisplay({
   region, rasterMetadata, model, emission,
 }) {
   const [longTermTimeSeries, setLongTermTimeSeries] = useState(null);
-  const [variable, setVariable] = useState(null);
 
-  const selectVariable = setVariable;
-
+  const storeVariable = useStore((state) => state.setYearlyIndicator);
+  const variable = useStore((state) => state.yearlyIndicator);
+  
   function dontSelectVariable(event) {
     // nothing happens here, as we are not using cascading selection
   }
@@ -51,7 +52,7 @@ function YearlyDataDisplay({
             metadata={rasterMetadata}
             value={variable}
             canReplace={false}
-            onChange={selectVariable}
+            onChange={storeVariable}
             onNoChange={dontSelectVariable}
           />
         )

--- a/src/data-services/ncwms.js
+++ b/src/data-services/ncwms.js
@@ -1,0 +1,48 @@
+// This file contains functions used to make metadata requests of the ncWMS server.
+// Actual map image requests are made by leaflet using leaflet's own code; the 
+// functions in this file are used by the user-facing components of MapControls.
+import axios from 'axios';
+
+
+export function getColourBarURL(palette="default", logscale= false) {
+    const params = {
+        service: "WMS",
+        request: "GetLegendGraphic",
+        colorbaronly: "true",
+        vertical: "false",
+        palette: palette,
+        logscale: logscale,
+        width: 500,
+        height: 25
+    };
+    
+    const urlParams = new URLSearchParams(params);
+    
+    return process.env.REACT_APP_NCWMS_URL + "?" + urlParams;
+}
+
+//returns a promise for a JSON object containing the minimum and maximum values of the dataset
+export function getNcwmsMinMax(file, variable) {
+    
+    const params = {
+        service: "WMS",
+        request: "GetMetadata",
+        item: "minmax",
+        layers: "x/" + file + "/" + variable,
+        version: "1.1.1",
+        srs: "EPSG:4326",
+        bbox: "-141,41,-52,84",
+        width: 100,
+        height: 100
+    };
+    
+    return axios.get(
+    process.env.REACT_APP_NCWMS_URL,
+        {
+            params: params
+        }
+    )
+    .then(response => response.data);
+}
+
+//https://services.pacificclimate.org/dev/ncwms?%2Fcdd&styles=default-scalar&version=1.1.1&bbox=-141,41,-52.00000356,83.49999830000002&srs=EPSG:4326&crs=EPSG:4326&time=1977-07-02T00:00:00Z&elevation=0&width=100&height=100

--- a/src/data-services/ncwms.js
+++ b/src/data-services/ncwms.js
@@ -12,7 +12,7 @@ export function getColourBarURL(palette="default", logscale= false) {
         vertical: "false",
         palette: palette,
         logscale: logscale,
-        width: 500,
+        width: 400,
         height: 25
     };
     
@@ -37,7 +37,7 @@ export function getNcwmsMinMax(file, variable) {
     };
     
     return axios.get(
-    process.env.REACT_APP_NCWMS_URL,
+        process.env.REACT_APP_NCWMS_URL,
         {
             params: params
         }
@@ -45,4 +45,20 @@ export function getNcwmsMinMax(file, variable) {
     .then(response => response.data);
 }
 
-//https://services.pacificclimate.org/dev/ncwms?%2Fcdd&styles=default-scalar&version=1.1.1&bbox=-141,41,-52.00000356,83.49999830000002&srs=EPSG:4326&crs=EPSG:4326&time=1977-07-02T00:00:00Z&elevation=0&width=100&height=100
+// returns the list of available colour palettes.
+// this requires a dataset, for some reason.
+export function getNcwmsPalettes(file, variable) {
+    const params = {
+        service: "WMS", 
+        request: "GetMetadata",
+        item: "layerDetails",
+        layerName: "x/" + file + "/" + variable
+    };
+    
+    return axios.get(
+        process.env.REACT_APP_NCWMS_URL,
+        {
+            params: params
+        }
+    ).then(response => response.data.palettes);
+}

--- a/src/data-services/pcex-backend.js
+++ b/src/data-services/pcex-backend.js
@@ -4,6 +4,8 @@
 import axios from 'axios';
 import {map, keys, pick} from 'lodash';
 import {geoJSONtoWKT, MAXAREALENGTH} from '../helpers/GeographyHelpers.js';
+import _ from 'lodash';
+
 
 // Functions for accessing the multimeta API, which returns a list of
 // available datafiles, and some metadata about each one
@@ -65,6 +67,29 @@ export function getMetadata(dataset) {
   )
   .then(response => response.data);
 }
+
+// the metadata API returns an object with a single attribute whose key is the file_id
+// and whose value is all the other attributes. We'd prefer a one-layer object.
+// the API also makes allowances for multiple variables in one file, but since no
+// files in this project are formatted that way, flatten lists of variables into single
+// attributes.
+export function flattenMetadata(response) {
+    const unmodified_attributes = ["institution", "model_id", "model_name",
+                                    "experiment", "ensemble_member", "modtime",
+                                    "filepath", "timescale", "multi_year_mean",
+                                    "start_date", "end_date"];
+    const file_id = keys(response)[0];
+    let metadata = _.pick(response[file_id], unmodified_attributes);
+    metadata["file_id"] = file_id;
+    const variable_id = keys(response[file_id].variables)[0];
+    metadata["variable_id"] = variable_id;
+    metadata["variable_description"] = response[file_id].variables[variable_id];
+    metadata["units"] = response[file_id].units[variable_id];
+    const times = _.values(response[file_id].times);
+    metadata["times"] = times.sort();
+    return metadata;
+}
+
 
 // Functions for accessing the raster data retrieval APIs, "timeseries" and "data".
 // These APIs are accessed with a GET request if possible (to take advantage of

--- a/src/data-services/pcex-backend.js
+++ b/src/data-services/pcex-backend.js
@@ -52,6 +52,20 @@ export function flattenMultimeta(response) {
     })
 }
 
+// get more information on a dataset, so that it can be displayed on the map.
+export function getMetadata(dataset) {
+    return axios.get(
+    process.env.REACT_APP_PCEX_API_URL + "/metadata",
+    {
+      params: {
+        model_id: dataset,
+        extras: "filepath",
+      }
+    }
+  )
+  .then(response => response.data);
+}
+
 // Functions for accessing the raster data retrieval APIs, "timeseries" and "data".
 // These APIs are accessed with a GET request if possible (to take advantage of
 // caching), but will use POST if the area string is too long for GET.

--- a/src/data-services/public.js
+++ b/src/data-services/public.js
@@ -12,3 +12,11 @@ export function getWhitelist(whitelist) {
         .then(response => response.data)
         .then(yaml.safeLoad);
 }
+
+// accesses configuration file of indicator map display options
+export function getIndicatorMapOptions() {
+    const url = `${process.env.PUBLIC_URL}/map_indicators.yaml`;
+    return axios.get(url)
+        .then(response => response.data)
+        .then(yaml.safeLoad);
+}

--- a/src/helpers/APIDataHelpers.js
+++ b/src/helpers/APIDataHelpers.js
@@ -48,3 +48,18 @@ export function taxonObject(taxonStr, taxonObjects){
     let f = _.find(taxonObjects, t => {return taxonString(t) === taxonStr;});
     return f;
 }
+
+// returns the first and only item in a one-item list. 
+// returns null if the list is empty, throws an error if there
+// is more than one item.
+export function only(list) {
+    if (list.length === 0) {
+        return null;
+    }
+    else if (list.length === 1) {
+        return list[0];
+    }
+    else {
+        throw new Error(`List contains more than one item: ${list}`);
+    }
+}

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -1,0 +1,53 @@
+// zustand data store. This holds some state information used by the entire App, 
+// specifically data generated far "down" the component tree by user input, but 
+// which one of the other branches of the component tree (Data, Map, Area) needs 
+// to respond to. 
+
+import {create} from "zustand";
+
+const startingEmission = {
+    isDisabled: false,
+    label: "Historical, then RCP 8.5",
+    value: {
+        contexts: [],
+        representative: {experiment: "historical, rcp85"}
+    }
+};
+
+const startingModel = {
+    isDisabled: false,
+    label: "PCIC-HYDRO",
+    value: {
+        contexts: [],
+        representative: {model_id: "PCIC-HYDRO"}
+    }
+};
+
+
+const useStore = create((set) => {
+        return {
+            // graph indicator - tracks which graph and indicator the user is looking 
+            // at (in DataDisplay, DailyDataDisplay, MonthlyDataDisplay, YearlyDataDisplay) 
+            // so that the map can be updated to match it by MapControls (which uses this
+            // state but doesn't change it)
+            graphTab: "year",
+            setGraphTab: (tab) => set((state) => ({graphTab: tab})),
+            yearlyIndicator: null,
+            setYearlyIndicator: (ind) => set((state) => ({yearlyIndicator: ind})),
+            monthlyIndicator: null,
+            setMonthlyIndicator: (ind) => set((state) => ({monthlyIndicator: ind})),
+            dailyIndicator: null,
+            setDailyIndicator: (ind) => set((state) => ({dailyIndicator: ind})),
+            
+            // climate model and emissions scenario - set un the DataDisplay, consumed
+            // by MapControls, used to decide which dataset to display on the map.
+            model: startingModel,
+            setModel: (mod) => set((state) => ({model: mod})),
+            emission: startingEmission,
+            setEmission: (em) => set((state) => ({emission: em})),
+
+        }
+    }
+);
+
+export default useStore;


### PR DESCRIPTION
Adds the functionality to view indicator data on the map. To see indicator data, you can pick any of the indicators on the Yearly, Monthly, or Daily tabs. The arrows below the map allow you to go forward and backwards one timestep or jump to the next or previous climatology.

Very interested in feedback on the map colours. It was difficult to find balance between colours palettes that sort of evoked the thing being measured, were visible against the background, and were sufficiently differentiated between high and low values.

[Demo](https://services.pacificclimate.org/dev/scip/app/)

This is the last bit of functionality to be added before initial release, so I am also very interested in any places the UI feels clunky, buggy, confusing, or ugly.

resolves #37 
resolves #47