### PR TITLE
Small UI Improvements based on scientist feedback

### DIFF
--- a/public/basins.yaml
+++ b/public/basins.yaml
@@ -3,7 +3,6 @@
 # coverage of.
 
 - Fraser River
-- Haida Gwaii
 - Mainland Coast
 - Skeena River
 - Southwest Coast

--- a/public/basins.yaml
+++ b/public/basins.yaml
@@ -3,9 +3,11 @@
 # coverage of.
 
 - Fraser River
-- Nass River
+- Haida Gwaii
+- Mainland Coast
 - Skeena River
 - Southwest Coast
-- Stewart
+- Stewart-Nass
 - Stikine River
 - Taku River
+- Vancouver Island

--- a/public/map_indicators.yaml
+++ b/public/map_indicators.yaml
@@ -1,6 +1,6 @@
 # This file configures how indicators will be shown on the map.
 # Each indicator can be configured with a colour palette and
-# a boolean for whether or not to plot on the map with a logscaled
+# a boolean for whether or not to allow a logscaled
 # colour scale (only works when indicator is always greater than 0. 
 # List of available ncWMS colour palettes is here:
 # https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/04-usage.html
@@ -22,7 +22,7 @@ lowQ05_year:
     palette: psu-viridis
 
 peakQmag_year:
-    logscale: false
+    logscale: true
     palette: seq-BlueHeat-inv
 
 peakQday_year: 
@@ -39,7 +39,7 @@ POT19freq_year:
 
 #monthly indicators
 flow_month:
-    logscale: false
+    logscale: true
     palette: seq-BlueHeat-inv
 
 tw_month:
@@ -48,7 +48,7 @@ tw_month:
 
 #daily indicators
 flow_day:
-    logscale: false
+    logscale: true
     palette: seq-BlueHeat-inv
 
 tw_day:

--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -7,6 +7,7 @@ import {getUpstream} from '../../data-services/pcex-backend.js';
 import {getWhitelist} from '../../data-services/public.js';
 import AreaSelector from '../AreaSelector/AreaSelector.js';
 import TaxonSelector from '../TaxonSelector/TaxonSelector.js';
+import OutletToggle from '../OutletToggle/OutletToggle.js';
 import {Container, Row, Col} from 'react-bootstrap';
 import React, {useState, useEffect} from 'react';
 import {map, find} from 'lodash';
@@ -250,6 +251,12 @@ function collateRegions(regions, whitelist) {
                         kind={'conservation unit'}
                     />
                 </Col>
+            </Row>
+            <Row>
+                <Col>
+                    <OutletToggle region={region}/>
+                </Col>
+                <Col/>
             </Row>
           </Container>
       Select a region either using the circle marker tool on the map to place a

--- a/src/components/DailyDataDisplay/DailyDataDisplay.js
+++ b/src/components/DailyDataDisplay/DailyDataDisplay.js
@@ -22,6 +22,7 @@ function DailyDataDisplay({
   
   const storeVariable = useStore((state) => state.setDailyIndicator);
   const variable = useStore((state) => state.dailyIndicator);
+  const viewOutletIndicators = useStore((state) => state.viewOutletIndicators);
 
   const selectClimatology = setClimatology;
 
@@ -35,6 +36,7 @@ function DailyDataDisplay({
 
   useEffect(() => {
     if (region && variable && climatology && rasterMetadata) {
+      const area = viewOutletIndicators ? JSON.parse(region.outlet) : region.boundary;
       const datafiles = _.filter(rasterMetadata, {
         variable_id: variable.value.representative.variable_id,
         experiment: emission,
@@ -44,13 +46,13 @@ function DailyDataDisplay({
       });
 
       const api_calls = _.map(datafiles, (datafile) => annualCycleDataRequest(
-        region.boundary,
+        area,
         datafile.file_id,
         variable.value.representative.variable_id,
       ));
       Promise.all(api_calls).then((api_responses) => setDailyTimeSeries(api_responses));
     }
-  }, [region, variable, model, emission, rasterMetadata, climatology]);
+  }, [region, variable, model, emission, rasterMetadata, climatology, viewOutletIndicators]);
 
   const graphMetadata = {
     area: region ? region.name : 'no region selected',

--- a/src/components/DailyDataDisplay/DailyDataDisplay.js
+++ b/src/components/DailyDataDisplay/DailyDataDisplay.js
@@ -99,7 +99,7 @@ function DailyDataDisplay({
         : noGraphMessage({
           climatology,
           indicator: variable,
-          watershed: region,
+          region: region,
         })}
     </div>
   );

--- a/src/components/MapControls/LogScaleCheckbox.js
+++ b/src/components/MapControls/LogScaleCheckbox.js
@@ -19,9 +19,7 @@ function LogScaleCheckbox({mapDataset, minmax, handleChange, indicatorConfig}) {
     
     //TODO: uncomment this function when data issue is fixed.
     //function allowLogscale() {
-    //    return indicatorConfig 
-    //        && mapDataset.variable in indicatorConfig 
-    //        && indicatorConfig[mapDataset.variable].logscale
+    //    return indicatorConfig?.[mapDataset.variable]?,logscale 
     //        && minmax.min >= .01; 
     //}
     function allowLogscale() {return false};

--- a/src/components/MapControls/LogScaleCheckbox.js
+++ b/src/components/MapControls/LogScaleCheckbox.js
@@ -5,7 +5,26 @@
 import React from 'react';
 import Form from 'react-bootstrap/Form';
 
-function LogScaleCheckbox({mapDataset, minmax, handleChange}) {
+function LogScaleCheckbox({mapDataset, minmax, handleChange, indicatorConfig}) {
+
+    // logscaled colour is allowed (can be turned on by user) for only those
+    // variables that say so in the configuration file. Additionally, the minimum
+    // value of the data range must be > 0
+    
+    // at present, due to a data bug, the files that are supposed to always have
+    // data greater than zero (stream flow magnitude files) have some zero values, 
+    // perhaps due to a rounding error. This causes ncWMS to throw an error when
+    // asked to display them with a logarithmic colour scale, so this function is
+    // disabled for now.
+    
+    //TODO: uncomment this function when data issue is fixed.
+    //function allowLogscale() {
+    //    return indicatorConfig 
+    //        && mapDataset.variable in indicatorConfig 
+    //        && indicatorConfig[mapDataset.variable].logscale
+    //        && minmax.min >= .01; 
+    //}
+    function allowLogscale() {return false};
 
     return (
         <Form.Check
@@ -15,8 +34,8 @@ function LogScaleCheckbox({mapDataset, minmax, handleChange}) {
             onChange={handleChange}
             inline
             label={"Log scale"}
-            title={minmax.min <= 0 ? "Logscale not possible for datasets containing values less than 1" : "Logarithmic Scale"}
-            disabled={minmax.min <= 1}
+            title={minmax.min <= 1 ? "Logscale not possible for datasets containing values less than 1" : "Logarithmic Scale"}
+            disabled={!allowLogscale()}
         />
     );
 

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -121,8 +121,7 @@ function MapControls({onChange, mapDataset}) {
                 }
                 
                 //use indicator-specific colouration if available
-                const config = indicatorConfig && indicator in indicatorConfig ?
-                    indicatorConfig[indicator] : false; 
+                const config = indicatorConfig?.[indicator]; 
                 const palette = config ? config.palette : 'x-Occam';
 
                 // currently data is buggy - datasets that are supposed to 

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -59,7 +59,7 @@ function MapControls({onChange, mapDataset}) {
         }
     }, [mapDataset]);
 
-    // this useEffect responds to user changes and selections made on the Data Display
+    // this useEffect responds to user changes in selected dataset made on the Data Display
     // component or its children, which it receives via the Zustand store.
     // it determines which datasets are described by the selection parameters and loads
     // one of them.
@@ -121,11 +121,21 @@ function MapControls({onChange, mapDataset}) {
                 }
                 
                 //use indicator-specific colouration if available
-                const palette = (indicatorConfig && indicator in indicatorConfig) ?
-                    indicatorConfig[indicator].palette : 'x-Occam';
-                const logscale = (indicatorConfig && indicator in indicatorConfig) ?
-                    indicatorConfig[indicator].logscale : false;
-                
+                const config = indicatorConfig && indicator in indicatorConfig ?
+                    indicatorConfig[indicator] : false; 
+                const palette = config ? config.palette : 'x-Occam';
+
+                // currently data is buggy - datasets that are supposed to 
+                // always be greater than zero (stream flow magnitudes)
+                // contain zeros. ncWMS throws an error if asked to display
+                // a dataset with zero values and logarithmic scale colour.
+                // Accordingly, since there are no datasets that can actualle
+                // BE displayed with logairthmic colour scaling right noe, 
+                // logarithmic scaling is disabled.
+                // TODO: uncomment following line when data is fixed.                
+                // const logscale = config ? config.logscale : false;
+                const logscale = false;
+                                
                 const mapDataLayer = {
                     file: metadata.filepath,
                     variable: indicator,
@@ -150,7 +160,7 @@ function MapControls({onChange, mapDataset}) {
     }
     
     // updates a single attribute of the displayed dataset, 
-    // used in cases where the dataset itself hasn't change, only
+    // used in cases where the dataset itself hasn't changed, only
     // the way it is displayed, so we don't need to fetch a new dataset.
     function updateMapDisplayParameter(parameter, value) {
         let newMapDataLayer = {...mapDataset};
@@ -388,6 +398,7 @@ function MapControls({onChange, mapDataset}) {
                     mapDataset={mapDataset}
                     minmax={datasetMinMax}
                     handleChange={handleLogScale}
+                    indicatorConfig={indicatorConfig}
                   />
                 </Col>
                 <Col>

--- a/src/components/MapControls/MapControls.js
+++ b/src/components/MapControls/MapControls.js
@@ -8,6 +8,7 @@ import useStore from '../../store/useStore.js'
 import React, {useState, useEffect} from 'react';
 import {Container, Row, Col} from 'react-bootstrap';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Button from 'react-bootstrap/Button';
 import {getMetadata, flattenMetadata} from '../../data-services/pcex-backend.js';
 import {getNcwmsMinMax} from '../../data-services/ncwms.js'; 
 import {getIndicatorMapOptions} from '../../data-services/public.js';
@@ -365,7 +366,13 @@ function MapControls({onChange, mapDataset}) {
                 disabled={!previousTimestampExists()}
                 onClick={previousTimestamp}
               />
-              {describeMap()}
+              <Button
+                variant="secondary" 
+                size="sm"
+                title={describeMap()}
+                disabled={true}>
+                  {describeMap()}
+              </Button>
               <NextTimestampButton
                 disabled={!nextTimestampExists()}
                 onClick={nextTimestamp}
@@ -387,6 +394,7 @@ function MapControls({onChange, mapDataset}) {
               </Row>
               <Row>
                 <Col>
+                  Map Palette
                   <PaletteSelector
                       mapDataset={mapDataset}
                       handleChange={handlePalette}
@@ -401,6 +409,7 @@ function MapControls({onChange, mapDataset}) {
                   />
                 </Col>
                 <Col>
+                  Opacity
                   <OpacitySlider
                     mapDataset={mapDataset}
                     handleChange={handleOpacity}

--- a/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
+++ b/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
@@ -19,6 +19,8 @@ function MonthlyDataDisplay({
     
   const storeVariable = useStore((state) => state.setMonthlyIndicator);
   const variable = useStore((state) => state.monthlyIndicator);
+  const viewOutletIndicators = useStore((state) => state.viewOutletIndicators);
+
   
   function dontSelectVariable(event) {
     // no-op, as we are not using cascading selection
@@ -26,6 +28,7 @@ function MonthlyDataDisplay({
 
   useEffect(() => {
     if (region && variable && rasterMetadata) {
+      const area = viewOutletIndicators ? JSON.parse(region.outlet) : region.boundary;
       const datafiles = _.filter(rasterMetadata, {
         variable_id: variable.value.representative.variable_id,
         experiment: emission,
@@ -33,13 +36,13 @@ function MonthlyDataDisplay({
       });
 
       const api_calls = _.map(datafiles, (datafile) => annualCycleDataRequest(
-        region.boundary,
+        area,
         datafile.file_id,
         variable.value.representative.variable_id,
       ));
       Promise.all(api_calls).then((api_responses) => setAnnualCycleTimeSeries(api_responses));
     }
-  }, [region, variable, model, emission, rasterMetadata]);
+  }, [region, variable, model, emission, rasterMetadata, viewOutletIndicators]);
 
   const graphMetadata = {
     area: region ? region.name : 'no region selected',

--- a/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
+++ b/src/components/MonthlyDataDisplay/MonthlyDataDisplay.js
@@ -74,7 +74,7 @@ function MonthlyDataDisplay({
           />
         )
         : noGraphMessage({
-          watershed: region,
+          region: region,
           indicator: variable,
         })}
     </div>

--- a/src/components/OutletToggle/OutletToggle.js
+++ b/src/components/OutletToggle/OutletToggle.js
@@ -1,0 +1,38 @@
+// allows users to switch between showing mean data across the entire selected area
+// and showing data at the outlet only, if the outlet is known.
+
+import Form from 'react-bootstrap/Form';
+import React from 'react';
+import useStore from '../../store/useStore.js';
+
+function OutletToggle({region}) {
+    
+    const storeViewOutletIndicators = useStore((state) => state.setViewOutletIndicators);
+    const viewOutletIndicators = useStore((state) => state.viewOutletIndicators);
+    
+    function outletKnown() {
+        if(region && region.outlet) {
+            const outlet = JSON.parse(region.outlet);
+            return ( outlet.coordinates.length === 2);
+        }
+        return false;
+    }
+        
+    function handleChange(event) {
+        storeViewOutletIndicators(!viewOutletIndicators);
+    }
+
+    return (
+        <Form.Check
+          disabled = {!outletKnown()}
+          type="switch"
+          value={viewOutletIndicators && outletKnown()} 
+          onChange={handleChange}
+          label="View Indictors at outlet only"
+        />
+    );
+    
+    
+}
+
+export default OutletToggle;

--- a/src/components/PopulationDisplay/PopulationDisplay.js
+++ b/src/components/PopulationDisplay/PopulationDisplay.js
@@ -21,7 +21,7 @@ function PopulationDisplay({region}) {
                 populations={salmonPopulations}
             />
             : noGraphMessage({
-              watershed: region,
+              region: region,
           })}
     </div>
     );

--- a/src/components/PopulationTable/PopulationTable.js
+++ b/src/components/PopulationTable/PopulationTable.js
@@ -24,6 +24,14 @@ export function PopulationTable({populations}) {
         {field: 'name', flex: 1} //grant extra horizonal space to this column.
     ];
     
+    const title = (
+        <p>
+        <strong>Salmon population in selected area</strong>
+        <br />
+        Only populations with associated indicator data are selectable on the conservation unit menu.
+        </p>
+        );
+    
     //this is different than merely waiting for data to load.
     //if we are waiting for an initial data load, populations 
     //is undefined. If there are no salmon in an area, populations
@@ -33,8 +41,7 @@ export function PopulationTable({populations}) {
     return (
         <div class="ag-theme-alpine" style={{height: "400px", "text-align": "left"}}>
         {noSalmonHere ? 
-            "No salmon populations recorded at this location" : 
-            "Salmon populations in selected area"
+            "No salmon populations recorded at this location" : title
         }
         {noSalmonHere ? "" :
             <AgGridReact

--- a/src/components/YearlyDataDisplay/YearlyDataDisplay.js
+++ b/src/components/YearlyDataDisplay/YearlyDataDisplay.js
@@ -17,6 +17,8 @@ function YearlyDataDisplay({
 
   const storeVariable = useStore((state) => state.setYearlyIndicator);
   const variable = useStore((state) => state.yearlyIndicator);
+  const viewOutletIndicators = useStore((state) => state.viewOutletIndicators);
+
   
   function dontSelectVariable(event) {
     // nothing happens here, as we are not using cascading selection
@@ -24,8 +26,9 @@ function YearlyDataDisplay({
 
   useEffect(() => {
     if (region && variable) {
+      const area = viewOutletIndicators ? JSON.parse(region.outlet) : region.boundary;
       longTermAverageDataRequest(
-        region.boundary,
+        area,
         variable.value.representative.variable_id,
         model,
         emission,
@@ -35,7 +38,7 @@ function YearlyDataDisplay({
         setLongTermTimeSeries(data);
       });
     }
-  }, [region, variable, model, emission]);
+  }, [region, variable, model, emission, viewOutletIndicators]);
 
   const graphMetadata = {
     area: region ? region.name : 'no region selected',

--- a/src/components/YearlyDataDisplay/YearlyDataDisplay.js
+++ b/src/components/YearlyDataDisplay/YearlyDataDisplay.js
@@ -71,7 +71,7 @@ function YearlyDataDisplay({
           />
         )
         : noGraphMessage({
-          watershed: region,
+          region: region,
           indicator: variable,
         })}
     </div>

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -46,6 +46,19 @@ const useStore = create((set) => {
             emission: startingEmission,
             setEmission: (em) => set((state) => ({emission: em})),
 
+
+            // user-selected region and related data
+            // users may select a region either from a dropdown in AreaDisplay
+            // or by clicking on the map to select everything upstream in DataMap
+            // there's a lot of tangled logic related to handling regions in AreaDisplay 
+            // that should eventually be moved into this store.
+            // region selection data is consumed by *DataDisplay to generate graphs
+            region: null,
+            setRegion: (reg) => set((state) => ({region: reg})),
+            selectedOutlet: null,
+            setSelectedOutlet: (out) => set((state) => ({selectedOutlet: out})),
+            viewOutletIndicators: false,
+            setViewOutletIndicators: (view) => set((state) => ({viewOutletIndicators: view})),
         }
     }
 );

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -46,17 +46,12 @@ const useStore = create((set) => {
             emission: startingEmission,
             setEmission: (em) => set((state) => ({emission: em})),
 
-
             // user-selected region and related data
             // users may select a region either from a dropdown in AreaDisplay
             // or by clicking on the map to select everything upstream in DataMap
             // there's a lot of tangled logic related to handling regions in AreaDisplay 
             // that should eventually be moved into this store.
             // region selection data is consumed by *DataDisplay to generate graphs
-            region: null,
-            setRegion: (reg) => set((state) => ({region: reg})),
-            selectedOutlet: null,
-            setSelectedOutlet: (out) => set((state) => ({selectedOutlet: out})),
             viewOutletIndicators: false,
             setViewOutletIndicators: (view) => set((state) => ({viewOutletIndicators: view})),
         }


### PR DESCRIPTION
This PR combines a few small UI improvements requested by scientists:

1. Different spatial organization of river basins (split mainland into multiple basins)  (basins.yaml - most of the work here was in the database)
2. Add a note that you can only view salmon populations if we also have indicator data for them (PopulationTable.js)
3. Allow users to choose whether to view indicator data averaged over the entire region, or only at the outlet point (AreaDisplay.js, OutletToggle.js, DailyDataDisplay.js, MonthlyDataDisplay.js, YearlyDataDisplay.js, useStore.js)
4. Enable logarithmic colour scaling for certain indicators only (MapControls.js, LogscaleCheckbox.js)
5. Disable logarithmic colour scaling entirely, because upon further examination, all the data files for those indicators contain zero values and cannot be viewed with logarithmic colour scaling after all - ncWMS throws an error if you ask it to generate a logarithmic image of a dataset with zeroes in it (MapControls.js, LogscaleCheckbox.js)

Since these are UI changes, please feel free to weigh in on where the UI is clunky or could be improved.

[Demo](https://services.pacificclimate.org/dev/scip/app/)

Resolves #60 