### PR TITLE
Use data minmax consistently by indicator

### DIFF
--- a/public/map_indicators.yaml
+++ b/public/map_indicators.yaml
@@ -1,7 +1,9 @@
 # This file configures how indicators will be shown on the map.
 # Each indicator can be configured with a colour palette and
 # a boolean for whether or not to allow a logscaled
-# colour scale (only works when indicator is always greater than 0. 
+# colour scale (only works when indicator is always greater than 0),
+# and minimum and maximum expected values so colour scale is consistent
+# across data files.
 # List of available ncWMS colour palettes is here:
 # https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/04-usage.html
 
@@ -16,41 +18,61 @@
 highQ95_year:
     logscale: false
     palette: psu-viridis
+    minimum: 0
+    maximum: 250
 
 lowQ05_year:
     logscale: false
     palette: psu-viridis
+    minimum: 0
+    maximum: 250
 
 peakQmag_year:
     logscale: true
     palette: seq-BlueHeat-inv
+    minimum: 0.0001
+    maximum: 10000
 
 peakQday_year: 
     logscale: false
     palette: psu-viridis
+    minimum: 1
+    maximum: 365
 
 POT19dur_year: 
     logscale: false
     palette: psu-viridis
+    minimum: 0
+    maximum: 100
 
 POT19freq_year:
     logscale: false
     palette: psu-viridis
+    minimum: 0
+    maximum: 200
 
 #monthly indicators
 flow_month:
     logscale: true
     palette: seq-BlueHeat-inv
+    minimum: 0.0001
+    maximum: 8500
 
 tw_month:
     logscale: false
     palette: div-Spectral-inv
+    minimum: 0
+    maximum: 30
 
 #daily indicators
 flow_day:
     logscale: true
     palette: seq-BlueHeat-inv
+    minimum: 0.0001
+    maximum: 10000
 
 tw_day:
     logscale: false
     palette: div-Spectral-inv
+    minimum: 0
+    maximum: 35

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -14,14 +14,25 @@ import './App.css';
 import pcic_logo from '../../assets/pcic_logo.png';
 
 import {Container, Row, Col} from 'react-bootstrap';
-import DataDisplay from '../DataDisplay/DataDisplay.js'
-import MapDisplay from '../MapDisplay/MapDisplay.js'
-import AreaDisplay from '../AreaDisplay/AreaDisplay.js'
-import React, {useState} from 'react'
+import DataDisplay from '../DataDisplay/DataDisplay.js';
+import MapDisplay from '../MapDisplay/MapDisplay.js';
+import AreaDisplay from '../AreaDisplay/AreaDisplay.js';
+import React, {useState, useEffect} from 'react';
+import useStore from '../../store/useStore.js';
+import {getIndicatorMapOptions} from '../../data-services/public.js';
 
 function App() {
   const [region, setRegion] = useState(null);
   const [selectedOutlet, setSelectedOutlet] = useState(null);
+
+  //load-once-per-app config files
+  const storeIndicatorOptions = useStore((state) => state.setIndicatorOptions);
+
+  //load config files into zustand for components
+    useEffect(() => {
+
+        getIndicatorMapOptions().then((options) => storeIndicatorOptions(options));
+    }, []);
 
   function handleRegionChange(region, fromOutlet) {
       setRegion(region);

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -11,7 +11,7 @@ import {useState} from 'react';
 import _ from 'lodash';
 
 
-function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, dataset}) {
+function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, dataset, datasetMinMax}) {
   const viewport = BCBaseMap.initialViewport;
   const [cmMap, setCMMap] = useState(null);
   
@@ -103,12 +103,16 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
   // parameters in the "params" objecf. Therefore, we need anything that
   // might change over the course of a user session to be in this 
   // object.
-  const wmsParams = dataset ? {
+  let wmsParams = dataset ? {
     layers: `x${dataset.file}/${dataset.variable}`,
     time: dataset.time,
     styles: dataset.styles,
     logscale: dataset.logscale,
     }: {};
+
+    if(dataset && datasetMinMax) {
+        wmsParams["colorscalerange"] = `${datasetMinMax.min},${datasetMinMax.max}`;
+    }
 
   return (
     <div className="DataMap">

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -8,12 +8,16 @@ import SimpleGeoJSON from '../SimpleGeoJSON/SimpleGeoJSON.js';
 import { WMSTileLayer, FeatureGroup } from 'react-leaflet';
 import { EditControl } from 'react-leaflet-draw';
 import {useState} from 'react';
+import useStore from '../../store/useStore.js';
 import _ from 'lodash';
 
 
-function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, dataset, datasetMinMax}) {
+function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, dataset}) {
   const viewport = BCBaseMap.initialViewport;
   const [cmMap, setCMMap] = useState(null);
+  // indicator display options loaded from a config file - used for max and min
+  const indicatorOptions = useStore((state) => state.indicatorOptions);
+
   
   //convert the geoJSON to a Feature so it can be displayed on the map.
   const boundaryFeature = regionBoundary ? {
@@ -110,8 +114,16 @@ function DataMap({regionBoundary, downstream, onSelectOutlet, selectedOutlet, da
     logscale: dataset.logscale,
     }: {};
 
-    if(dataset && datasetMinMax) {
-        wmsParams["colorscalerange"] = `${datasetMinMax.min},${datasetMinMax.max}`;
+    //use indicator-specific minimum and maximum for consistency across climatologies
+    const minmaxAvailable = dataset && indicatorOptions?.[dataset.variable]; 
+
+    //check to see if we have expected minmax available for this indicator
+    if(dataset && indicatorOptions?.[dataset.variable]) {
+        wmsParams["colorscalerange"] =
+          `${indicatorOptions[dataset.variable].minimum},${indicatorOptions[dataset.variable].maximum}`;
+    }
+    else if (dataset) {
+        console.log(`WARNING: missing configuration data for indicator ${dataset.variable}`);
     }
 
   return (

--- a/src/components/MapControls/ColourLegend.js
+++ b/src/components/MapControls/ColourLegend.js
@@ -1,7 +1,16 @@
 //Displays a colour bar and minimum and maximum values. Display-only component, not interactive.
 import {getColourBarURL} from '../../data-services/ncwms.js';
+import useStore from '../../store/useStore.js'
 
-function ColourLegend({mapDataset, minmax, units}) {
+
+function ColourLegend({mapDataset, units}) {
+
+    const indicatorOptions = useStore((state) => state.indicatorOptions);
+
+    const config = indicatorOptions?.[mapDataset.variable];
+    const min = config ? config.minimum : "min";
+    const max = config ? config.maximum : "max";
+
     
     function palette() {
         return mapDataset.styles.split('/')[1];
@@ -10,12 +19,12 @@ function ColourLegend({mapDataset, minmax, units}) {
 
     return(
         <div>
-          <strong>{mapDataset.variable} ({units}):</strong> {minmax.min}
+          <strong>{mapDataset.variable} ({units}):</strong> {min}
           <img 
             src={getColourBarURL(palette(), mapDataset.logscale)}
             alt={"colour legend for the map"} 
           />
-          {minmax.max}
+          {max}
         </div>
     );
 

--- a/src/components/MapControls/LogScaleCheckbox.js
+++ b/src/components/MapControls/LogScaleCheckbox.js
@@ -4,8 +4,9 @@
 
 import React from 'react';
 import Form from 'react-bootstrap/Form';
+import useStore from '../../store/useStore.js'
 
-function LogScaleCheckbox({mapDataset, minmax, handleChange, indicatorConfig}) {
+function LogScaleCheckbox({mapDataset, handleChange}) {
 
     // logscaled colour is allowed (can be turned on by user) for only those
     // variables that say so in the configuration file. Additionally, the minimum
@@ -19,10 +20,14 @@ function LogScaleCheckbox({mapDataset, minmax, handleChange, indicatorConfig}) {
     
     //TODO: uncomment this function when data issue is fixed.
     //function allowLogscale() {
-    //    return indicatorConfig?.[mapDataset.variable]?,logscale 
-    //        && minmax.min >= .01; 
+    //    return const options = indicatorOptions?.[mapDataset.variable]?.logscale;
     //}
     function allowLogscale() {return false};
+
+    const indicatorOptions = useStore((state) => state.indicatorOptions);
+    const min = indicatorOptions?.[mapDataset.variable] ?
+        indicatorOptions[mapDataset.variable].minimum : 0;
+
 
     return (
         <Form.Check
@@ -32,7 +37,7 @@ function LogScaleCheckbox({mapDataset, minmax, handleChange, indicatorConfig}) {
             onChange={handleChange}
             inline
             label={"Log scale"}
-            title={minmax.min <= 1 ? "Logscale not possible for datasets containing values less than 1" : "Logarithmic Scale"}
+            title={min <= 1 ? "Logscale not possible for datasets containing values less than 1" : "Logarithmic Scale"}
             disabled={!allowLogscale()}
         />
     );

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -1,10 +1,9 @@
 // Handles map state and layout.
-// This component mostly passes props around. It will be very
-// short when we switch this app to zustand.
+// This component mostly passes props around. It should shrink as
+// more state is moved into zustand.
 //
-// MapDisplay "owns" two state objects, mapDataset and
-// datasetMinMax, both of which are set by MapControls and
-// consumed by DataMap, its children.
+// MapDisplay "owns" mapDataset and which is set by its child
+// MapControls and consumed by its other child DataMap
 //
 // Its child DataMap also sets selectedOutlet, which MapDisplay
 // passes upwards to App for eventual consumption by AreaDisplay.
@@ -23,7 +22,6 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
   
   const [downstream, setDownstream] = useState(null);
   const [mapDataset, setMapDataset] = useState(null);
-  const [datasetMinMax, setDatasetMinMax] = useState({});
 
   // fetch downstream data from the PCEX API
     useEffect(() => {
@@ -48,9 +46,6 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
       setMapDataset(dataset);
   }
 
-  function handleMinMaxChange(minmax) {
-      setDatasetMinMax(minmax);
-  }
 
   return (
     <div className="MapDisplay">
@@ -60,13 +55,10 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
           onSelectOutlet={handleSelectOutlet}
           selectedOutlet={selectedOutlet}
           dataset={mapDataset}
-          datasetMinMax={datasetMinMax}
         />
         <MapControls
           onChange={handleDatasetChange}
           mapDataset={mapDataset}
-          onMinMaxChange={handleMinMaxChange}
-          datasetMinMax={datasetMinMax}
         />
     </div>
   );

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -1,4 +1,16 @@
-// Handles map state and data fetching.
+// Handles map state and layout.
+// This component mostly passes props around. It will be very
+// short when we switch this app to zustand.
+//
+// MapDisplay "owns" two state objects, mapDataset and
+// datasetMinMax, both of which are set by MapControls and
+// consumed by DataMap, its children.
+//
+// Its child DataMap also sets selectedOutlet, which MapDisplay
+// passes upwards to App for eventual consumption by AreaDisplay.
+//
+// It receives region (set by AreaDisplay) from its parent
+// App and passes it to its child DataMap.
 
 import './MapDisplay.css';
 import DataMap from '../DataMap/DataMap.js'
@@ -11,6 +23,7 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
   
   const [downstream, setDownstream] = useState(null);
   const [mapDataset, setMapDataset] = useState(null);
+  const [datasetMinMax, setDatasetMinMax] = useState({});
 
   // fetch downstream data from the PCEX API
     useEffect(() => {
@@ -35,6 +48,10 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
       setMapDataset(dataset);
   }
 
+  function handleMinMaxChange(minmax) {
+      setDatasetMinMax(minmax);
+  }
+
   return (
     <div className="MapDisplay">
         <DataMap
@@ -43,10 +60,13 @@ function MapDisplay({region, onSelectOutlet, selectedOutlet}) {
           onSelectOutlet={handleSelectOutlet}
           selectedOutlet={selectedOutlet}
           dataset={mapDataset}
+          datasetMinMax={datasetMinMax}
         />
         <MapControls
           onChange={handleDatasetChange}
           mapDataset={mapDataset}
+          onMinMaxChange={handleMinMaxChange}
+          datasetMinMax={datasetMinMax}
         />
     </div>
   );

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -54,6 +54,12 @@ const useStore = create((set) => {
             // region selection data is consumed by *DataDisplay to generate graphs
             viewOutletIndicators: false,
             setViewOutletIndicators: (view) => set((state) => ({viewOutletIndicators: view})),
+
+            // configuration files that are loaded once (by App) and used by various
+            // components
+            // variable map display options (map colour, log scale, minmax)
+            indicatorOptions: {},
+            setIndicatorOptions: (options) => set((state) => ({indicatorOptions: options}))
         }
     }
 );


### PR DESCRIPTION
Adds an entry to the variable configuration files stating the expected minimum and maximum values of each variable, and uses those values as the minimum and maximum of the colour ramp for each variable across all datasets with that variable.

This allows a consistent comparison of map images  between climatologies and timestamps within a climatology. Previously, the minimum and maximum of the colour ramp were chosen for each image on an ad-hoc basis.

Resolves #68 