### PR TITLE
Push a docker to dockerhub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,19 +9,20 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Export REACT_APP_VERSION env var
         run: |
           git fetch --prune --unshallow
           echo "REACT_APP_VERSION=$(git describe --tags --abbrev=0) ($(git rev-parse --abbrev-ref HEAD):$(git log -1 --format=%h))" >> $GITHUB_ENV
       - name: Publish to Registry
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}
           repository: pcic/scip-frontend
           dockerfile: docker/Dockerfile
           tag_with_ref: true
+          build_args: REACT_APP_APP_VERSION=${{ env.REACT_APP_APP_VERSION }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,26 @@
+name: Docker Publishing
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Export REACT_APP__VERSION env var
+        run: |
+          git fetch --prune --unshallow
+          echo "REACT_APP_VERSION=$(git describe --tags --abbrev=0) ($(git rev-parse --abbrev-ref HEAD):$(git log -1 --format=%h))" >> $GITHUB_ENV
+      - name: Publish to Registry
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.pcicdevops_at_dockerhub_username }}
+          password: ${{ secrets.pcicdevops_at_dockerhub_password }}
+          repository: pcic/scip-frontend
+          tag_with_ref: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ jobs:
           git fetch --prune --unshallow
           echo "REACT_APP_VERSION=$(git describe --tags --abbrev=0) ($(git rev-parse --abbrev-ref HEAD):$(git log -1 --format=%h))" >> $GITHUB_ENV
       - name: Publish to Registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Export REACT_APP__VERSION env var
+      - name: Export REACT_APP_VERSION env var
         run: |
           git fetch --prune --unshallow
           echo "REACT_APP_VERSION=$(git describe --tags --abbrev=0) ($(git rev-parse --abbrev-ref HEAD):$(git log -1 --format=%h))" >> $GITHUB_ENV
@@ -23,4 +23,5 @@ jobs:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}
           repository: pcic/scip-frontend
+          dockerfile: docker/Dockerfile
           tag_with_ref: true

--- a/README.md
+++ b/README.md
@@ -123,21 +123,3 @@ After a few minutes of create-react-app building, one should be able
 to access the frontend at:
 
 http://localhost/frontend
-
-and geoserver at:
-
-http://localhost/geoserver
-
-
-## How to update the SCIP demo instance
-
-This application has not yet had a full release, and has no production instances, but there is a semipermanent demo instance running on docker-dev02. You will not need to worry about CORS or proxies when working with this instance, as a proxy is already set up for it.
-
-1. Clone this repository to anywhere on docker-dev02 and check out whatever branch you want to demo 
-2. Build the docker image with `docker build -t scip:your-branch-name -f docker/Dockerfile .`
-3. Make a new dated directory in `/storage/data/projects/comp_support/bc-srif/dev/` for your demo and copy files into it from the most recent existing directory (note these are not the same as the docker-compose files files in this repository)
-4. Update `docker-compose.yaml` in your new directory with the name of the image you built
-5. Update `fe.env` if needed
-6. Do `docker-compose down` in the directory of the current demo to bring down the current containers
-7. Do `docker-compose up -d` in your new directory to launch your containers
-8. Demo will be available at https://services.pacificclimate.org/dev/scip/app/


### PR DESCRIPTION
This app has not previously been on dockerhub, and has needed to be built locally for each deployment. Added a github workflow that publishes the docker container.

Resolves #26 